### PR TITLE
feat: add Cognee op tests to generated agent test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## @soleri/forge@4.2.2 — 2026-03-04
+
+### Added
+
+- **Cognee operation tests in generated agents** — scaffolded test suites now cover `cognee_status`, `cognee_sync`, and `graph_search` ops, verifying graceful degradation when Cognee is unavailable
+
 ## @soleri/core@2.0.1 — 2026-03-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Give it a name, a domain, a voice. It ships with starter knowledge and learns fr
 | Package | Version | Description |
 |---------|---------|-------------|
 | [`@soleri/core`](packages/core) | 2.0.1 | Shared engine — Vault, Brain, Planner, LLM utilities, facade infrastructure, Cognee hybrid search |
-| [`@soleri/forge`](packages/forge) | 4.2.1 | Agent scaffolder — generates config-driven MCP agents with optional Cognee integration |
+| [`@soleri/forge`](packages/forge) | 4.2.2 | Agent scaffolder — generates config-driven MCP agents with optional Cognee integration |
 | [`@soleri/cli`](packages/cli) | 1.0.1 | Developer CLI — create, manage, and develop agents from the terminal |
 | [`create-soleri`](packages/create-soleri) | 1.0.0 | `npm create soleri` shorthand — delegates to `@soleri/cli` |
 

--- a/packages/forge/package.json
+++ b/packages/forge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soleri/forge",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Scaffold AI agents that learn, remember, and grow with you.",
   "keywords": [
     "agent",

--- a/packages/forge/src/templates/test-facades.ts
+++ b/packages/forge/src/templates/test-facades.ts
@@ -554,6 +554,33 @@ ${domainDescribes}
       expect(results[0].score).toBeGreaterThan(0);
       expect(results[0].breakdown.total).toBe(results[0].score);
     });
+
+    // ─── Cognee ops (graceful degradation without Docker) ─────────
+
+    it('cognee_status should report not configured when cognee is undefined', async () => {
+      const facade = makeCoreFacade();
+      const op = facade.ops.find((o) => o.name === 'cognee_status')!;
+      expect(op).toBeDefined();
+      const result = (await op.handler({})) as { available: boolean };
+      expect(result.available).toBe(false);
+    });
+
+    it('cognee_sync should return helpful message when cognee is unavailable', async () => {
+      const facade = makeCoreFacade();
+      const op = facade.ops.find((o) => o.name === 'cognee_sync')!;
+      expect(op).toBeDefined();
+      const result = (await op.handler({})) as { synced: boolean; message: string };
+      expect(result.synced).toBe(false);
+      expect(result.message).toContain('Cognee not available');
+    });
+
+    it('graph_search should return empty results when cognee is unavailable', async () => {
+      const facade = makeCoreFacade();
+      const op = facade.ops.find((o) => o.name === 'graph_search')!;
+      expect(op).toBeDefined();
+      const result = (await op.handler({ query: 'test' })) as { results: unknown[] };
+      expect(result.results).toEqual([]);
+    });
   });
 });
 `;


### PR DESCRIPTION
## Summary

- Scaffolded agents were missing test coverage for the 3 Cognee operations (`cognee_status`, `cognee_sync`, `graph_search`)
- Tests verify graceful degradation when Cognee is unavailable (no Docker required)
- Bumps forge to 4.2.2

## Test plan

- [x] 276 monorepo tests pass (215 core + 61 forge)
- [x] Scaffolded agent: 43/43 tests pass (was 40, +3 Cognee op tests)
- [x] Tests work without Cognee Docker — they validate the "unavailable" code path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 4.2.2 released

* **Tests**
  * Added test coverage for Cognee operations to verify graceful degradation when unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->