### PR TITLE
test: add contract drift detection for engine modules

### DIFF
--- a/packages/core/src/__tests__/module-manifest-drift.test.ts
+++ b/packages/core/src/__tests__/module-manifest-drift.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Contract Drift Detection — Issue #227
+ *
+ * Ensures ENGINE_MODULE_MANIFEST (used by forge for template generation)
+ * stays in sync with ENGINE_MODULES (used by register-engine at runtime).
+ *
+ * If this test fails, someone added/removed/renamed a module in one place
+ * but not the other. Fix by updating both files to match.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ENGINE_MODULE_MANIFEST } from '../engine/module-manifest.js';
+import { ENGINE_MODULES } from '../engine/register-engine.js';
+
+describe('Module manifest drift detection', () => {
+  const manifestSuffixes = ENGINE_MODULE_MANIFEST.map((m) => m.suffix);
+  const runtimeSuffixes = ENGINE_MODULES.map((m) => m.suffix);
+
+  it('manifest and runtime have the same number of modules', () => {
+    expect(manifestSuffixes).toHaveLength(runtimeSuffixes.length);
+  });
+
+  it('manifest and runtime have identical suffixes in the same order', () => {
+    expect(manifestSuffixes).toEqual(runtimeSuffixes);
+  });
+
+  it('conditional flags match between manifest and runtime', () => {
+    for (const manifest of ENGINE_MODULE_MANIFEST) {
+      const runtime = ENGINE_MODULES.find((m) => m.suffix === manifest.suffix);
+      expect(runtime, `module "${manifest.suffix}" missing from ENGINE_MODULES`).toBeDefined();
+
+      const runtimeConditional = runtime!.condition !== undefined;
+      const manifestConditional = manifest.conditional === true;
+
+      expect(runtimeConditional, `conditional flag mismatch for "${manifest.suffix}"`).toBe(
+        manifestConditional,
+      );
+    }
+  });
+
+  it('no runtime module is missing from manifest', () => {
+    for (const runtime of ENGINE_MODULES) {
+      const manifest = ENGINE_MODULE_MANIFEST.find((m) => m.suffix === runtime.suffix);
+      expect(
+        manifest,
+        `module "${runtime.suffix}" exists in ENGINE_MODULES but missing from ENGINE_MODULE_MANIFEST`,
+      ).toBeDefined();
+    }
+  });
+
+  it('every manifest entry has at least one keyOp', () => {
+    for (const entry of ENGINE_MODULE_MANIFEST) {
+      expect(
+        entry.keyOps.length,
+        `module "${entry.suffix}" has empty keyOps — placeholder tables need at least one op`,
+      ).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/core/src/engine/register-engine.ts
+++ b/packages/core/src/engine/register-engine.ts
@@ -75,7 +75,8 @@ interface ModuleDef {
   condition?: (runtime: AgentRuntime) => boolean;
 }
 
-const ENGINE_MODULES: ModuleDef[] = [
+/** @internal Exported for drift testing — do not use outside engine */
+export const ENGINE_MODULES: ModuleDef[] = [
   {
     suffix: 'vault',
     description: 'Knowledge management — search, CRUD, import/export, intake, archival.',


### PR DESCRIPTION
## Summary

- Adds `module-manifest-drift.test.ts` with 5 assertions that verify `ENGINE_MODULE_MANIFEST` (used by forge for template generation) stays in sync with `ENGINE_MODULES` (used at runtime by register-engine)
- Exports `ENGINE_MODULES` from `register-engine.ts` for test access
- No workflow changes needed — test runs automatically in the existing `core` CI job

## What it catches

| Drift scenario | Test that catches it |
|----------------|---------------------|
| Module added to runtime but not manifest | "no runtime module is missing from manifest" |
| Module added to manifest but not runtime | "manifest and runtime have identical suffixes" |
| Module renamed in one but not other | suffix parity check |
| Module reordered | ordering check |
| Conditional flag mismatch | conditional flags check |
| Empty keyOps (broken placeholder tables) | "every manifest entry has at least one keyOp" |

## Test plan

- [x] 5 new tests pass
- [x] Full core suite: 87 files, 1918 tests pass
- [x] Build clean
- [x] All lint gates pass

Closes #227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation tests to verify module manifest synchronization, including module counts, ordering consistency, conditional flags, registry completeness, and key operation mappings.

* **Refactor**
  * Updated internal module registry structure with expanded visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->