### PR TITLE
docs: consolidate extension model — two clear tiers, deprecate plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Two layers, cleanly separated:
 
 - **Agent Folder** — Plain files (YAML, Markdown, JSON). your AI editor reads them natively. No code generation, no compilation.
 - **Knowledge Engine (`@soleri/core`)** — Persistent state for all agents. Vault (SQLite + FTS5), Brain (hybrid TF-IDF + optional Cognee vector search), Planner (state machine), Curator (dedup, grooming), and cross-project memory.
-- **Domain Packs** — Pluggable expertise modules (`@soleri/domain-design`, `@soleri/domain-component`, etc.). Add capabilities without code changes.
+- **Extensions** — Two tiers: **Domain Packs** (npm packages like `@soleri/domain-design`) for published intelligence, and **Local Packs** (project directories with `soleri-pack.json`) for project-specific knowledge, skills, and hooks. All extensions receive a narrowed `PackRuntime` (vault + projects + session checks).
 - **Model-agnostic** — The engine runs on pure SQLite FTS5 and TF-IDF math. Works without API keys. Optional Cognee integration adds vector embeddings and knowledge graph.
 
 ### Persistence

--- a/docs/architecture/capability-packs.md
+++ b/docs/architecture/capability-packs.md
@@ -3,7 +3,12 @@
 > RFC v2 — Soleri's evolution beyond Salvador's static atomic chains
 > Updated after multi-layer gap analysis against Soleri codebase
 
-## Status: Draft (v2)
+## Status: Draft (v2) — Partially Implemented
+
+> **Note:** The extension model has been consolidated (see `extension-tiers.md`).
+> PackRuntime narrowing (#224) and plugin deprecation (#226) are complete.
+> The capability registry exists but is not yet wired to domain packs at runtime.
+> This RFC remains as the design document for the capability system.
 
 ## Problem
 

--- a/docs/architecture/extension-tiers.md
+++ b/docs/architecture/extension-tiers.md
@@ -1,0 +1,101 @@
+# Extension Tiers
+
+Soleri has two extension tiers. Use the simplest one that fits your need.
+
+## Tier 1: Domain Packs (npm packages)
+
+**For:** Published, reusable domain intelligence distributed via npm.
+
+**Format:** npm package exporting a `DomainPack` object.
+
+**What they provide:**
+- Custom ops with algorithmic logic (e.g., WCAG contrast checking)
+- Standalone facades (one pack can register multiple MCP tools)
+- Tiered knowledge (canonical/curated/captured)
+- CLAUDE.md behavioral rules
+- Skills
+- Capability declarations
+
+**Runtime access:** `PackRuntime` (vault, projects, session checks). Full `AgentRuntime` available as deprecated fallback.
+
+**Examples:** `@soleri/domain-design`, `@soleri/domain-component`, `@soleri/domain-code-review`
+
+**When to use:**
+- You're building domain intelligence that multiple agents will consume
+- You need custom algorithmic ops (not just knowledge)
+- You want to publish to npm
+
+```yaml
+# In agent.yaml
+packs:
+  - name: design
+    package: '@soleri/domain-design'
+```
+
+## Tier 2: Local Packs (project directories)
+
+**For:** Project-specific knowledge, skills, hooks, and facades installed from local directories.
+
+**Format:** Directory with `soleri-pack.json` manifest.
+
+**What they provide:**
+- Vault intelligence bundles (JSON)
+- Facades (via optional `index.js`)
+- Skills (Markdown)
+- Hooks (Markdown)
+- Capability declarations
+
+**Runtime access:** `PackRuntime` via `PluginContext.packRuntime`.
+
+**When to use:**
+- You're bundling project-specific knowledge
+- You want to install skills and hooks together
+- You don't need to publish to npm
+
+```bash
+soleri pack install ./my-local-pack
+```
+
+**Directory structure:**
+```
+my-pack/
+  soleri-pack.json       # manifest (required)
+  index.js               # facade builder (optional)
+  vault/                 # intelligence JSON bundles (optional)
+  skills/                # skill .md files (optional)
+  hooks/                 # hook .md files (optional)
+```
+
+## Deprecated: Plugins
+
+The `soleri-plugin.json` format is deprecated. It's a subset of local packs (facades + intelligence entries only, no vault/skills/hooks). Use `soleri-pack.json` instead.
+
+The plugin registry is still used internally by the pack installer for facade registration, but new extensions should use the pack system directly.
+
+## Comparison
+
+| Concern | Domain Pack | Local Pack | Plugin (deprecated) |
+|---------|------------|------------|---------------------|
+| Distribution | npm | Local directory | Local directory |
+| Manifest | `DomainPack` export | `soleri-pack.json` | `soleri-plugin.json` |
+| Custom ops | Yes | Yes (via `index.js`) | Yes (via `index.js`) |
+| Vault seeding | Yes (via `knowledge`) | Yes (via `vault/`) | No |
+| Skills | Yes | Yes | No |
+| Hooks | No | Yes | No |
+| Capabilities | Yes | Yes | No |
+| Runtime access | `PackRuntime` | `PackRuntime` | `PackRuntime` |
+
+## Runtime Access: PackRuntime
+
+All extensions receive `PackRuntime` — a narrowed interface that exposes only what packs need:
+
+| Module | Purpose |
+|--------|---------|
+| `vault` | Knowledge search and capture |
+| `getProject(id)` | Token resolution for registered projects |
+| `listProjects()` | Enumerate registered projects |
+| `createCheck()` | Session checks for tool chaining |
+| `validateCheck()` | Validate a session check |
+| `validateAndConsume()` | Validate and consume a single-use check |
+
+Extensions do NOT have access to: brain, planner, curator, governance, LLM client, key pools, auth policy, or other internal modules.

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -1,5 +1,9 @@
 /**
  * Plugin System — Barrel Exports
+ *
+ * @deprecated Prefer knowledge packs (soleri-pack.json) for new extensions.
+ * The plugin system is maintained for backwards compatibility and is used
+ * internally by the pack installer for facade registration.
  */
 
 export {

--- a/packages/core/src/plugins/plugin-registry.ts
+++ b/packages/core/src/plugins/plugin-registry.ts
@@ -1,6 +1,10 @@
 /**
  * Plugin Registry — tracks loaded plugins and their lifecycle.
  *
+ * @deprecated The plugin system is superseded by knowledge packs (`soleri-pack.json`).
+ * This registry is still used internally by the pack installer to register facades,
+ * but new extensions should use the pack system directly.
+ *
  * Not a singleton — lives on AgentRuntime for testability.
  * Lifecycle: load → register → activate → (deactivate | error)
  */
@@ -161,7 +165,8 @@ export class PluginRegistry {
       throw new Error(`Plugin module "${moduleFile}" must export createFacades(ctx)`);
     } catch (e) {
       throw new Error(
-        `Failed to load plugin module "${moduleFile}": ${e instanceof Error ? e.message : String(e)}`, { cause: e },
+        `Failed to load plugin module "${moduleFile}": ${e instanceof Error ? e.message : String(e)}`,
+        { cause: e },
       );
     }
   }

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -1,9 +1,12 @@
 /**
  * Plugin System — Types & Manifest Schema
  *
- * A plugin is a directory containing a `soleri-plugin.json` manifest
- * and optionally additional intelligence data. Plugins register
- * OpDefinition[] (facades) dynamically without re-scaffolding.
+ * @deprecated Prefer knowledge packs (`soleri-pack.json`) over plugins (`soleri-plugin.json`).
+ * Knowledge packs are a superset of plugins — they support facades, vault entries, skills,
+ * hooks, and capability declarations. Plugins only support facades and intelligence entries.
+ *
+ * This module is maintained for backwards compatibility. New extensions should use
+ * the pack system in `../packs/`. See docs/architecture/extension-tiers.md.
  */
 
 import { z } from 'zod';


### PR DESCRIPTION
## Summary

- Deprecate `soleri-plugin.json` format in favor of `soleri-pack.json` (plugins are a strict subset)
- Add `@deprecated` JSDoc to plugin types, registry, and barrel index
- Create `docs/architecture/extension-tiers.md` — canonical reference for extension model
- Update README and capability-packs.md

## Extension Tiers (after this PR)

| Tier | Format | Use case |
|------|--------|----------|
| **Domain Packs** | npm package exporting `DomainPack` | Published, reusable domain intelligence |
| **Local Packs** | `soleri-pack.json` directory | Project-specific knowledge, skills, hooks |
| ~~Plugins~~ | ~~`soleri-plugin.json`~~ | **Deprecated** — use local packs |

## Test plan

- [x] Core: 86 files, 1902 tests pass
- [x] Build clean
- [x] All lint gates pass
- [x] No runtime behavior changes — existing plugins still work

Closes #226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified extension system with two tiers: Domain Packs (npm packages) and Local Packs (project directories), each with distinct contents and access patterns.
  * Added comprehensive reference documentation for extension architecture and runtime access model.
  * Updated status and implementation notes for capability system.
  * Marked plugin system as deprecated; knowledge packs now the recommended approach for new extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->