### PR TITLE
chore: version compatibility contract — peer deps, vault format, engine checks

### DIFF
--- a/docs/architecture/version-compatibility.md
+++ b/docs/architecture/version-compatibility.md
@@ -1,0 +1,96 @@
+# Version Compatibility Contract
+
+Soleri packages version independently but must remain compatible. This document defines what breaks, what's safe, and how to verify.
+
+## Packages
+
+| Package | Role | Versioning |
+|---------|------|-----------|
+| `@soleri/core` | Engine runtime | Semver — breaking changes = major bump |
+| `@soleri/forge` | Agent scaffolder | Follows core major version |
+| `@soleri/cli` | Developer CLI | Follows core major version |
+| `@soleri/domain-*` | Domain packs | Independent semver, declares `@soleri/core` peer dep |
+| Knowledge packs | Local packs | `soleri-pack.json` manifest with optional `engine` field |
+
+## Compatibility Rules
+
+### Rule 1: All first-party packages share a major version
+
+`@soleri/core`, `@soleri/forge`, and `@soleri/cli` are released together. A major version bump in core means a major bump in forge and cli.
+
+### Rule 2: Domain packs declare peer dependency on core
+
+Every `@soleri/domain-*` package must declare:
+```json
+"peerDependencies": {
+  "@soleri/core": "^8.0.0"
+}
+```
+
+The caret range (`^`) allows minor/patch updates. A new core major version requires domain packs to release a compatible version.
+
+### Rule 3: Vault format is versioned
+
+The vault database tracks its schema version via SQLite `PRAGMA user_version`. The engine checks this on startup:
+
+- **Fresh database** — stamped with current format version
+- **Compatible version** — proceeds normally
+- **Newer than engine** — throws error with upgrade guidance
+- **Older than engine** — future: run migration scripts
+
+Current format version: **1** (introduced in v8.0.0)
+
+### Rule 4: Knowledge packs can declare engine requirement
+
+The `engine` field in `soleri-pack.json` specifies the minimum engine version:
+
+```json
+{
+  "engine": ">=8.0.0"
+}
+```
+
+This is validated at install time. Packs without `engine` are assumed compatible.
+
+## What Constitutes a Breaking Change
+
+### Major version bump required
+
+- Vault schema changes (new required columns, removed tables, renamed fields)
+- `PackRuntime` interface changes (added required methods, removed methods)
+- `DomainPack` interface changes (changed `onActivate` signature)
+- Engine module suffix changes (tool names change)
+- Removed ops from semantic facades
+
+### Minor version bump (non-breaking)
+
+- New optional fields on existing types
+- New ops added to existing facades
+- New engine modules (new MCP tools)
+- New `PackRuntime` optional methods
+- Performance improvements to FTS/brain
+
+### Patch version bump
+
+- Bug fixes
+- Documentation updates
+- Internal refactors with no API changes
+
+## Compatibility Matrix
+
+| Core | Forge | CLI | Domain Packs | Vault Format |
+|------|-------|-----|-------------|-------------|
+| 8.x | 8.x | 8.x | peer: `^8.0.0` | 1 |
+
+## Verification
+
+```bash
+# Check all package versions
+soleri agent status
+
+# Validate installed packs against engine
+soleri pack list
+
+# Check vault format
+# (automatic on engine start — errors if incompatible)
+```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.0.0",
-    "@soleri/core": "^2.0.0",
+    "@soleri/core": "^8.0.0",
     "@soleri/forge": "^5.0.0",
     "commander": "^13.0.0"
   },

--- a/packages/core/src/domain-packs/loader.ts
+++ b/packages/core/src/domain-packs/loader.ts
@@ -18,7 +18,8 @@ export async function loadDomainPack(packageName: string): Promise<DomainPackMan
     mod = await import(packageName);
   } catch (err) {
     throw new Error(
-      `Failed to import domain pack "${packageName}": ${err instanceof Error ? err.message : String(err)}`, { cause: err },
+      `Failed to import domain pack "${packageName}": ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
     );
   }
 
@@ -33,10 +34,29 @@ export async function loadDomainPack(packageName: string): Promise<DomainPackMan
     throw new Error(`Domain pack "${packageName}" failed validation: ${result.errors.message}`);
   }
 
-  return {
-    ...result.data,
-    packageName,
-  };
+  const manifest: DomainPackManifest = { ...result.data, packageName };
+
+  // Warn if pack's engine requirement is mismatched
+  try {
+    const pkgJson = await import(`${packageName}/package.json`, { with: { type: 'json' } })
+      .then((m) => m.default)
+      .catch(() => null);
+    const peerCore = pkgJson?.peerDependencies?.['@soleri/core'];
+    if (peerCore) {
+      const requiredMajor = parseInt(peerCore.replace(/[^0-9]/g, ''), 10);
+      const { ENGINE_MAJOR_VERSION } = await import('../engine/module-manifest.js');
+      if (requiredMajor && ENGINE_MAJOR_VERSION && requiredMajor > ENGINE_MAJOR_VERSION) {
+        console.error(
+          `[warn] Domain pack "${packageName}" requires @soleri/core ${peerCore} ` +
+            `but engine is v${ENGINE_MAJOR_VERSION}. Upgrade @soleri/core.`,
+        );
+      }
+    }
+  } catch {
+    // Version check is best-effort — don't block loading
+  }
+
+  return manifest;
 }
 
 /**

--- a/packages/core/src/engine/module-manifest.ts
+++ b/packages/core/src/engine/module-manifest.ts
@@ -94,3 +94,6 @@ export const ENGINE_MODULE_MANIFEST: ModuleManifestEntry[] = [
 
 /** Core facade ops (always present, not in ENGINE_MODULES) */
 export const CORE_KEY_OPS = ['health', 'identity', 'register', 'activate'];
+
+/** Engine major version — used for compatibility checks against domain packs. */
+export const ENGINE_MAJOR_VERSION = 8;

--- a/packages/core/src/vault/vault.ts
+++ b/packages/core/src/vault/vault.ts
@@ -76,6 +76,32 @@ export class Vault {
         providerOrPath instanceof SQLitePersistenceProvider ? providerOrPath : null;
     }
     this.initialize();
+    this.checkFormatVersion();
+  }
+
+  /**
+   * Vault format version — tracks schema changes for migration safety.
+   * Increment when schema changes in a way that requires migration.
+   *
+   * History:
+   *   1 — Initial schema (v8.0.0): entries, memories, brain_feedback, FTS5
+   */
+  static readonly FORMAT_VERSION = 1;
+
+  private checkFormatVersion(): void {
+    const row = this.provider.get<{ user_version: number }>('PRAGMA user_version');
+    const current = row?.user_version ?? 0;
+
+    if (current === 0) {
+      // Fresh database — stamp with current version
+      this.provider.run(`PRAGMA user_version = ${Vault.FORMAT_VERSION}`);
+    } else if (current > Vault.FORMAT_VERSION) {
+      throw new Error(
+        `Vault format version ${current} is newer than engine supports (${Vault.FORMAT_VERSION}). ` +
+          `Upgrade @soleri/core to a compatible version.`,
+      );
+    }
+    // current < FORMAT_VERSION → future: run migration scripts here
   }
 
   setSyncManager(mgr: import('../cognee/sync-manager.js').CogneeSyncManager): void {

--- a/packages/domain-code-review/package.json
+++ b/packages/domain-code-review/package.json
@@ -19,7 +19,7 @@
     "zod": "^3.24.2"
   },
   "peerDependencies": {
-    "@soleri/core": ">=2.0.0"
+    "@soleri/core": "^8.0.0"
   },
   "files": [
     "dist"

--- a/packages/domain-component/package.json
+++ b/packages/domain-component/package.json
@@ -19,7 +19,7 @@
     "zod": "^3.24.2"
   },
   "peerDependencies": {
-    "@soleri/core": ">=2.0.0"
+    "@soleri/core": "^8.0.0"
   },
   "files": [
     "dist"

--- a/packages/domain-design-qa/package.json
+++ b/packages/domain-design-qa/package.json
@@ -19,7 +19,7 @@
     "zod": "^3.24.2"
   },
   "peerDependencies": {
-    "@soleri/core": ">=2.0.0"
+    "@soleri/core": "^8.0.0"
   },
   "files": [
     "dist"

--- a/packages/domain-design/package.json
+++ b/packages/domain-design/package.json
@@ -20,7 +20,7 @@
     "zod": "^3.24.2"
   },
   "peerDependencies": {
-    "@soleri/core": ">=2.0.0"
+    "@soleri/core": "^8.0.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary

- **Fix stale peer deps**: CLI and 4 domain packs now declare `@soleri/core ^8.0.0` (were `^2.0.0` / `>=2.0.0`)
- **Vault format versioning**: `PRAGMA user_version` stamps fresh databases with format version 1. Engine rejects newer formats with clear upgrade guidance.
- **Engine version check**: Domain pack loader warns when pack's peer dep on `@soleri/core` exceeds engine version
- **`ENGINE_MAJOR_VERSION`** constant in module manifest for runtime checks
- **Compatibility doc**: `docs/architecture/version-compatibility.md` — semver rules, breaking change definitions, compatibility matrix

## What this prevents

| Scenario | Before | After |
|----------|--------|-------|
| Old domain pack + new engine | Silent incompatibility | Peer dep check at npm install |
| New vault opened by old engine | Silent data corruption | Error with upgrade guidance |
| Breaking schema change | No tracking | Format version bump + migration hook |

## Test plan

- [x] Core: 86 files, 1913 tests pass
- [x] Build clean
- [x] All lint gates pass

Closes #190