### PR TITLE
refactor: LLM provider abstraction — router-based, no hardcoded OpenAI

### DIFF
--- a/packages/core/src/brain/knowledge-synthesizer.ts
+++ b/packages/core/src/brain/knowledge-synthesizer.ts
@@ -114,8 +114,6 @@ export class KnowledgeSynthesizer {
     let llmOutput: string;
     try {
       const result = await this.llm.complete({
-        provider: 'openai',
-        model: 'gpt-4o-mini',
         systemPrompt,
         userPrompt,
         temperature: 0.3,

--- a/packages/core/src/curator/classifier.ts
+++ b/packages/core/src/curator/classifier.ts
@@ -58,8 +58,6 @@ export async function classifyEntry(
 
   try {
     const result = await llm.complete({
-      provider: 'openai',
-      model: 'gpt-4o-mini',
       systemPrompt: 'You are a knowledge classifier. Respond only with JSON.',
       userPrompt: prompt,
       temperature: 0.1,

--- a/packages/core/src/curator/quality-gate.ts
+++ b/packages/core/src/curator/quality-gate.ts
@@ -97,8 +97,6 @@ export async function evaluateQuality(
 
   try {
     const result = await llm.complete({
-      provider: 'openai',
-      model: 'gpt-4o-mini',
       systemPrompt: 'You are a knowledge quality evaluator. Respond only with JSON.',
       userPrompt: prompt,
       temperature: 0.1,

--- a/packages/core/src/intake/content-classifier.ts
+++ b/packages/core/src/intake/content-classifier.ts
@@ -60,8 +60,6 @@ export async function classifyChunk(
 ): Promise<ClassifiedItem[]> {
   try {
     const result = await llm.complete({
-      provider: 'openai',
-      model: 'gpt-4o-mini',
       systemPrompt: CLASSIFICATION_PROMPT,
       userPrompt: chunkText,
       maxTokens: 4096,

--- a/packages/core/src/llm/llm-client.ts
+++ b/packages/core/src/llm/llm-client.ts
@@ -160,6 +160,8 @@ interface AnthropicClient {
   };
 }
 
+type ResolvedLLMOptions = LLMCallOptions & { model: string; provider: 'openai' | 'anthropic' };
+
 export class LLMClient {
   private openaiKeyPool: KeyPool;
   private anthropicKeyPool: KeyPool;
@@ -181,11 +183,15 @@ export class LLMClient {
 
   async complete(options: LLMCallOptions): Promise<LLMCallResult> {
     const routed = this.router.resolve(options.caller, options.task, options.model);
-    const resolvedOptions = { ...options, model: routed.model, provider: routed.provider };
+    const resolved: ResolvedLLMOptions = {
+      ...options,
+      model: options.model ?? routed.model,
+      provider: options.provider ?? routed.provider,
+    };
 
-    return resolvedOptions.provider === 'anthropic'
-      ? this.callAnthropic(resolvedOptions)
-      : this.callOpenAI(resolvedOptions);
+    return resolved.provider === 'anthropic'
+      ? this.callAnthropic(resolved)
+      : this.callOpenAI(resolved);
   }
 
   isAvailable(): { openai: boolean; anthropic: boolean } {
@@ -203,7 +209,7 @@ export class LLMClient {
   // OPENAI
   // ===========================================================================
 
-  private async callOpenAI(options: LLMCallOptions): Promise<LLMCallResult> {
+  private async callOpenAI(options: ResolvedLLMOptions): Promise<LLMCallResult> {
     const keyPool = this.openaiKeyPool.hasKeys ? this.openaiKeyPool : null;
 
     if (!keyPool) {
@@ -275,7 +281,7 @@ export class LLMClient {
   // ANTHROPIC
   // ===========================================================================
 
-  private async callAnthropic(options: LLMCallOptions): Promise<LLMCallResult> {
+  private async callAnthropic(options: ResolvedLLMOptions): Promise<LLMCallResult> {
     const client = await this.getAnthropicClient();
     if (!client) {
       throw new LLMError('Anthropic API key not configured', { retryable: false });

--- a/packages/core/src/llm/types.ts
+++ b/packages/core/src/llm/types.ts
@@ -43,8 +43,10 @@ export class LLMError extends Error {
 }
 
 export interface LLMCallOptions {
-  provider: 'openai' | 'anthropic';
-  model: string;
+  /** Provider override. If omitted, the model router selects based on caller/task. */
+  provider?: 'openai' | 'anthropic';
+  /** Model override. If omitted, the model router selects based on caller/task. */
+  model?: string;
   systemPrompt: string;
   userPrompt: string;
   temperature?: number;

--- a/packages/core/src/runtime/facades/admin-facade.ts
+++ b/packages/core/src/runtime/facades/admin-facade.ts
@@ -58,8 +58,7 @@ export function createAdminFacadeOps(runtime: AgentRuntime): OpDefinition[] {
       }),
       handler: async (params) => {
         return llmClient.complete({
-          provider: 'openai',
-          model: (params.model as string) ?? '',
+          model: (params.model as string) || undefined,
           systemPrompt: params.systemPrompt as string,
           userPrompt: params.userPrompt as string,
           temperature: params.temperature as number | undefined,

--- a/packages/core/src/runtime/vault-linking-ops.ts
+++ b/packages/core/src/runtime/vault-linking-ops.ts
@@ -328,13 +328,11 @@ export function createVaultLinkingOps(runtime: AgentRuntime): OpDefinition[] {
 
           try {
             const result = await llmClient.complete({
-              provider: llmClient.isAvailable().anthropic ? 'anthropic' : 'openai',
-              model: llmClient.isAvailable().anthropic ? 'claude-sonnet-4-20250514' : 'gpt-4o-mini',
               systemPrompt: EVAL_SYSTEM_PROMPT,
               userPrompt: pairsText,
               maxTokens: 2000,
-              caller: 'relink_vault',
-              task: 'link-evaluation',
+              caller: 'vault-linking',
+              task: 'evaluate-links',
             });
             llmCalls++;
 


### PR DESCRIPTION
## Summary

Remove hardcoded `provider: 'openai'` and `model: 'gpt-4o-mini'` from all 6 internal LLM call sites. All calls now route through the existing model router.

**Changed files:**
- `quality-gate.ts` — removed hardcoded provider/model
- `classifier.ts` — removed hardcoded provider/model
- `content-classifier.ts` — removed hardcoded provider/model
- `knowledge-synthesizer.ts` — removed hardcoded provider/model
- `vault-linking-ops.ts` — replaced manual `isAvailable()` check with router
- `admin-facade.ts` — `llm_call` respects router when model not specified
- `llm-client.ts` — `provider` and `model` now optional on `LLMCallOptions`, `ResolvedLLMOptions` type for internal dispatch
- `types.ts` — `provider` and `model` made optional

## How routing works

```
llmClient.complete({ caller: 'quality-gate', task: 'evaluate', ... })
  → ModelRouter.resolve('quality-gate', 'evaluate')
  → Checks DefaultRoutes table → finds match
  → Returns { model: 'gpt-4o', provider: 'openai' }
  → User override: ~/.{agentId}/model-routing.json
```

Users can switch all engine LLM calls to Anthropic by creating `model-routing.json` with Anthropic models. No code changes needed.

## Test plan

- [x] Core: 86 files, 1913 tests pass
- [x] Build clean
- [x] All lint gates pass

Closes #192