### PR TITLE
fix(cli): create ~/.soleri dir before write-permission check

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,4 +1,4 @@
-import { accessSync, constants as fsConstants, readFileSync, existsSync } from 'node:fs';
+import { accessSync, constants as fsConstants, mkdirSync, readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { Command } from 'commander';
 import * as p from '@clack/prompts';
@@ -185,7 +185,15 @@ export function registerCreate(program: Command): void {
 
             const outputDir = opts?.dir ? resolve(opts.dir) : (config.outputDir ?? process.cwd());
 
-            // Preflight: check output directory is writable
+            // Preflight: ensure output directory exists and is writable
+            if (!existsSync(outputDir)) {
+              try {
+                mkdirSync(outputDir, { recursive: true });
+              } catch {
+                p.log.error(`Cannot create ${outputDir} — check permissions`);
+                process.exit(1);
+              }
+            }
             try {
               accessSync(outputDir, fsConstants.W_OK);
             } catch {

--- a/packages/forge/src/__tests__/extensions-scaffold.test.ts
+++ b/packages/forge/src/__tests__/extensions-scaffold.test.ts
@@ -13,7 +13,7 @@ describe('scaffold extensions', () => {
     rmSync(outputDir, { recursive: true, force: true });
   });
 
-  it('should create extensions directory with index and example op', () => {
+  it('should create extensions directory with index and example op', { timeout: 30_000 }, () => {
     scaffold({
       id: agentId,
       name: 'Extension Test',


### PR DESCRIPTION
## Summary
- On a clean machine, `npm create soleri` fails with "Cannot write to ~/.soleri — check permissions" because `accessSync` throws `ENOENT` when the default output directory doesn't exist yet, misreported as a permissions error. Now we `mkdirSync` the directory first.
- Bumps the `extensions-scaffold` test timeout to 30s — the legacy TypeScript scaffolder regularly takes ~9s, exceeding vitest's default 5s.

## Test plan
- [x] `npm run build` passes
- [x] `npx vitest run packages/forge/src/__tests__/extensions-scaffold.test.ts` passes (was timing out)
- [ ] `npm create soleri` on a clean machine without `~/.soleri` creates the directory and scaffolds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file creation process with automatic output directory generation. The system now attempts to create missing output directories automatically before proceeding with file operations. If directory creation fails due to permission issues, improved error messages will clearly identify the problem, helping you resolve permission-related issues more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->