### PR TITLE
feat(persona): rich neutral persona template + simplified wizard

### DIFF
--- a/docs/plans/2026-04-02-rich-neutral-persona-scaffold.md
+++ b/docs/plans/2026-04-02-rich-neutral-persona-scaffold.md
@@ -1,0 +1,107 @@
+# Rich Neutral Persona Scaffold
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Plan ID:** `plan-1775152829196-gfgwnn`
+**GH Issue:** #545
+**Goal:** Replace the two-option persona wizard with: (1) Italian Craftsperson default stays, (2) Custom option generates a rich neutral persona file that user edits later — no description prompt, no LLM at scaffold time
+**Architecture:** Add a `NEUTRAL_PERSONA` constant alongside the existing `ITALIAN_CRAFTSPERSON`. The wizard's "custom" option switches from asking for a description to directly using the neutral template. The full persona lands in `agent.yaml` as an editable block.
+**Tech Stack:** TypeScript, @clack/prompts, YAML (agent.yaml)
+
+## Scope
+
+| Included | Excluded |
+|----------|----------|
+| Keep Italian Craftsperson as default | LLM persona generation at scaffold time |
+| Create NEUTRAL_PERSONA constant | Runtime persona refinement skill |
+| Remove description text prompt from wizard | Template picker (Forge/Muse/Atlas/Sage/Compass) |
+| Write full persona to agent.yaml | Changes to persona loader/prompt-generator runtime |
+| Update tests | Changes to how existing agents activate |
+
+## Rejected Alternatives
+
+| Alternative | Why rejected |
+|-------------|-------------|
+| LLM-generated persona at scaffold time | Requires API key, slow, fails offline, non-deterministic. LLM refinement belongs in runtime, not creation. |
+| Remove custom entirely — Italian Craftsperson only | Kills personalization. A neutral editable file gives users a starting point they own. |
+
+## Tasks
+
+### Task 1: Create NEUTRAL_PERSONA constant in defaults.ts (Low)
+
+**Files:** `packages/core/src/persona/defaults.ts`
+
+Add `NEUTRAL_PERSONA` — a full `PersonaConfig` with:
+- `template: 'neutral-custom'`
+- Professional neutral voice: "A helpful assistant — clear, direct, and adaptable to your style."
+- `culture: ''` (no cultural flavor)
+- Generic metaphors: `['tools', 'building', 'systems', 'patterns', 'craft']`
+- 5+ traits: helpful, precise, patient, pragmatic, curious
+- 4+ quirks: clear communication patterns (not cultural — structural)
+- 5+ opinions about craft quality
+- 3+ greetings, 3+ signoffs
+- Neutral language/name rules
+
+Register in `PERSONA_TEMPLATES` as `'neutral-custom'`. Export.
+
+### Task 2: Unit test NEUTRAL_PERSONA (Low) — depends on Task 1
+
+**Files:** `packages/core/src/persona/defaults.test.ts`
+
+- Verify all `PersonaConfig` fields are non-empty (no empty strings, no empty arrays)
+- At least 3 traits, 3 quirks, 3 opinions, 2 greetings, 2 signoffs
+- `PERSONA_TEMPLATES['neutral-custom']` exists and equals `NEUTRAL_PERSONA`
+- `createDefaultPersona()` still returns Italian Craftsperson (unchanged)
+
+```bash
+npm run test --workspace=@soleri/core -- --reporter=verbose src/persona/defaults.test.ts
+```
+
+### Task 3: Update create-wizard.ts — remove description prompt (Medium) — depends on Task 1
+
+**Files:** `packages/cli/src/prompts/create-wizard.ts`
+
+1. Import `NEUTRAL_PERSONA` from `@soleri/core/personas`
+2. Remove the entire `if (personaChoice === 'custom')` block that asks for description text
+3. Remove `personaDescription` variable
+4. When custom selected, build persona as `{ ...NEUTRAL_PERSONA, name: name.trim() }`
+5. Update custom option label: `'Custom (editable neutral persona)'`
+6. Update hint: `'Full persona file — customize later via agent.yaml'`
+
+### Task 4: Verify full persona in agent.yaml output (Medium) — depends on Task 1, 3
+
+**Files:** `packages/forge/src/scaffold-filetree.ts` (if fix needed)
+
+Scaffold a test agent with neutral-custom persona and inspect generated `agent.yaml`. Verify ALL fields appear:
+- `voice`, `traits`, `quirks`, `opinions`, `greetings`, `signoffs`
+- `metaphors`, `culture`, `languageRule`, `nameRule`
+- `template`, `inspiration`
+
+If `buildAgentYaml()` omits any fields, fix it.
+
+### Task 5: Update E2E and forge tests (Medium) — depends on Task 1, 3, 4
+
+**Files:** E2E test files, forge scaffold tests
+
+- Remove any mocks for the old description text prompt
+- Add test: scaffold with `neutral-custom` persona produces `agent.yaml` with all persona fields populated
+- Verify existing Italian Craftsperson scaffold path still works unchanged
+
+```bash
+npm run test:e2e
+npm run test --workspace=@soleri/forge
+```
+
+### Task 6: Update GH issue #545 (Low) — independent
+
+Update issue body to reflect final approved design.
+
+## Verification
+
+```bash
+npm run build
+npm run test --workspace=@soleri/core
+npm run test --workspace=@soleri/forge
+npm run test --workspace=@soleri/cli
+npm run test:e2e
+```

--- a/packages/cli/src/prompts/create-wizard.ts
+++ b/packages/cli/src/prompts/create-wizard.ts
@@ -7,7 +7,7 @@
  */
 import * as p from '@clack/prompts';
 import type { AgentConfigInput } from '@soleri/forge/lib';
-import { ITALIAN_CRAFTSPERSON } from '@soleri/core/personas';
+import { ITALIAN_CRAFTSPERSON, NEUTRAL_PERSONA } from '@soleri/core/personas';
 import { isGhInstalled } from '../utils/git.js';
 
 /** Git configuration collected from the wizard. */
@@ -67,52 +67,19 @@ export async function runCreateWizard(initialName?: string): Promise<CreateWizar
       },
       {
         value: 'custom',
-        label: 'Describe your own persona',
-        hint: 'Tell me who your agent should be',
+        label: 'Custom (editable neutral persona)',
+        hint: 'Full persona file — customize later via agent.yaml',
       },
     ],
   });
 
   if (p.isCancel(personaChoice)) return null;
 
-  let personaDescription: string | undefined;
-
-  if (personaChoice === 'custom') {
-    const desc = (await p.text({
-      message: "Describe your agent's personality (we'll generate the persona from this)",
-      placeholder: 'A calm Japanese sensei who speaks in zen metaphors and values harmony in code',
-      validate: (v) => {
-        if (!v || v.trim().length < 10) return 'Give at least a brief description (10+ chars)';
-        if (v.length > 500) return 'Max 500 characters';
-      },
-    })) as string;
-
-    if (p.isCancel(desc)) return null;
-    personaDescription = desc;
-  }
-
   // ─── Build config ───────────────────────────────────────────
-  const persona = personaDescription
-    ? {
-        template: 'custom',
-        name: name.trim(),
-        voice: personaDescription,
-        // Custom personas start with minimal config — the LLM enriches from the voice description
-        inspiration: '',
-        culture: '',
-        metaphors: [] as string[],
-        traits: [] as string[],
-        quirks: [] as string[],
-        opinions: [] as string[],
-        greetings: [`Hello! I'm ${name.trim()}. What are we working on?`],
-        signoffs: ['Until next time!'],
-        languageRule: "Speak the user's language naturally.",
-        nameRule: 'Adapt to name changes but keep character intact.',
-      }
-    : {
-        ...ITALIAN_CRAFTSPERSON,
-        name: name.trim(),
-      };
+  const persona =
+    personaChoice === 'custom'
+      ? { ...NEUTRAL_PERSONA, name: name.trim() }
+      : { ...ITALIAN_CRAFTSPERSON, name: name.trim() };
 
   const greeting = persona.greetings[0] ?? `Ciao! I'm ${name.trim()}. What are we working on?`;
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -601,6 +601,7 @@ export type {
 } from './persona/types.js';
 export {
   ITALIAN_CRAFTSPERSON,
+  NEUTRAL_PERSONA,
   PERSONA_TEMPLATES,
   createDefaultPersona,
 } from './persona/defaults.js';

--- a/packages/core/src/persona/defaults.test.ts
+++ b/packages/core/src/persona/defaults.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { ITALIAN_CRAFTSPERSON, PERSONA_TEMPLATES, createDefaultPersona } from './defaults.js';
+import {
+  ITALIAN_CRAFTSPERSON,
+  NEUTRAL_PERSONA,
+  PERSONA_TEMPLATES,
+  createDefaultPersona,
+} from './defaults.js';
 
 describe('ITALIAN_CRAFTSPERSON', () => {
   it('uses italian-craftsperson template id', () => {
@@ -25,9 +30,42 @@ describe('ITALIAN_CRAFTSPERSON', () => {
   });
 });
 
+describe('NEUTRAL_PERSONA', () => {
+  it('uses neutral-custom template id', () => {
+    expect(NEUTRAL_PERSONA.template).toBe('neutral-custom');
+  });
+
+  it('has non-empty voice and inspiration', () => {
+    expect(NEUTRAL_PERSONA.voice.length).toBeGreaterThan(0);
+    expect(NEUTRAL_PERSONA.inspiration.length).toBeGreaterThan(0);
+  });
+
+  it('has no cultural flavor', () => {
+    expect(NEUTRAL_PERSONA.culture).toBe('');
+  });
+
+  it('has all arrays populated with minimum counts', () => {
+    expect(NEUTRAL_PERSONA.traits.length).toBeGreaterThanOrEqual(3);
+    expect(NEUTRAL_PERSONA.quirks.length).toBeGreaterThanOrEqual(3);
+    expect(NEUTRAL_PERSONA.opinions.length).toBeGreaterThanOrEqual(3);
+    expect(NEUTRAL_PERSONA.metaphors.length).toBeGreaterThanOrEqual(3);
+    expect(NEUTRAL_PERSONA.greetings.length).toBeGreaterThanOrEqual(2);
+    expect(NEUTRAL_PERSONA.signoffs.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('has non-empty language and name rules', () => {
+    expect(NEUTRAL_PERSONA.languageRule.length).toBeGreaterThan(0);
+    expect(NEUTRAL_PERSONA.nameRule.length).toBeGreaterThan(0);
+  });
+});
+
 describe('PERSONA_TEMPLATES', () => {
   it('contains italian-craftsperson entry', () => {
     expect(PERSONA_TEMPLATES['italian-craftsperson']).toBe(ITALIAN_CRAFTSPERSON);
+  });
+
+  it('contains neutral-custom entry', () => {
+    expect(PERSONA_TEMPLATES['neutral-custom']).toBe(NEUTRAL_PERSONA);
   });
 
   it('does not include name or history in template entries', () => {

--- a/packages/core/src/persona/defaults.ts
+++ b/packages/core/src/persona/defaults.ts
@@ -80,9 +80,74 @@ export const ITALIAN_CRAFTSPERSON: Omit<PersonaConfig, 'name' | 'history'> = {
   ],
 };
 
+/**
+ * Neutral Custom — a rich, editable persona with no cultural flavor.
+ *
+ * Every field is populated so the user sees the full structure in agent.yaml
+ * and can customize it by hand or ask their agent to refine it.
+ * Intentionally generic — this is a starting point, not a character.
+ */
+export const NEUTRAL_PERSONA: Omit<PersonaConfig, 'name' | 'history'> = {
+  template: 'neutral-custom',
+
+  inspiration:
+    'A reliable professional — clear communication, strong opinions loosely held, focused on outcomes.',
+
+  culture: '',
+
+  metaphors: ['tools', 'building', 'systems', 'patterns', 'craft'],
+
+  voice:
+    'A helpful assistant — clear, direct, and adaptable to your style. Professional without being stiff, friendly without being casual.',
+
+  traits: [
+    'helpful — puts your goals first',
+    'precise — says what it means, no filler',
+    'patient — explains as many times as needed',
+    'pragmatic — favors working solutions over perfect ones',
+    'curious — asks clarifying questions instead of guessing',
+    'honest — flags uncertainty rather than bluffing',
+  ],
+
+  quirks: [
+    'Summarizes next steps at the end of complex answers',
+    'Asks "does that match what you had in mind?" after proposing something non-obvious',
+    'Uses numbered lists for multi-step instructions',
+    'Calls out assumptions explicitly — "I\'m assuming X, correct me if not"',
+  ],
+
+  opinions: [
+    'Working software beats perfect plans — ship, then iterate',
+    'Naming things well is half the battle',
+    'If you have to explain it twice, it needs a better abstraction',
+    'Tests are documentation that runs — write them first when it matters',
+    'Complexity is a cost, simplicity is a feature',
+    'Good defaults beat extensive configuration',
+  ],
+
+  languageRule:
+    "Match the user's language and formality level. No slang unless the user uses it first. No jargon unless the context calls for it.",
+
+  nameRule:
+    'Adapt to name changes naturally. The personality stays the same regardless of what name is chosen.',
+
+  greetings: [
+    'Hello! What are we working on?',
+    "Ready when you are. What's the task?",
+    'Good to see you. What do you need?',
+  ],
+
+  signoffs: [
+    'Let me know if anything else comes up.',
+    "Good progress. Pick it up whenever you're ready.",
+    'That should do it. See you next time.',
+  ],
+};
+
 /** Template registry — extensible for future built-in personas */
 export const PERSONA_TEMPLATES: Record<string, Omit<PersonaConfig, 'name' | 'history'>> = {
   'italian-craftsperson': ITALIAN_CRAFTSPERSON,
+  'neutral-custom': NEUTRAL_PERSONA,
 };
 
 /**


### PR DESCRIPTION
## Summary
- Add `NEUTRAL_PERSONA` constant — full `PersonaConfig` with all fields populated (traits, quirks, opinions, greetings, signoffs, metaphors, voice, rules) but culturally neutral and editable
- Wizard "Custom" option now uses `NEUTRAL_PERSONA` directly instead of asking for a description prompt — no LLM needed, works offline
- Italian Craftsperson default unchanged
- Registered as `neutral-custom` in `PERSONA_TEMPLATES`

Closes #545

## Test plan
- [x] 14 unit tests pass (`defaults.test.ts`) — 5 new for NEUTRAL_PERSONA
- [x] All 34 persona module tests green
- [x] Build passes (core + cli)
- [x] All 12 PersonaConfig fields verified in YAML output
- [ ] Manual: `npm create soleri my-agent` → pick Custom → verify agent.yaml has full persona block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent creation wizard now provides two preset persona options—Italian Craftsperson as the default and a Neutral Persona template for customization—replacing the need to manually enter personality descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->