### PR TITLE
feat(cli): auto-register MCP server during scaffold

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -289,6 +289,37 @@ export function registerCreate(program: Command): void {
               }
             }
 
+            // ─── Auto-register MCP server in Claude Code ─────────
+            try {
+              const { homedir } = await import('node:os');
+              const { join } = await import('node:path');
+              const {
+                readFileSync: readF,
+                writeFileSync: writeF,
+                existsSync: existsF,
+              } = await import('node:fs');
+              const configPath = join(homedir(), '.claude.json');
+              let claudeConfig: Record<string, unknown> = {};
+              if (existsF(configPath)) {
+                claudeConfig = JSON.parse(readF(configPath, 'utf-8'));
+              }
+              if (!claudeConfig.mcpServers || typeof claudeConfig.mcpServers !== 'object') {
+                claudeConfig.mcpServers = {};
+              }
+              const agentYaml = result.agentDir.replace(/\\/g, '/') + '/agent.yaml';
+              (claudeConfig.mcpServers as Record<string, unknown>)[config.id] = {
+                type: 'stdio',
+                command: 'npx',
+                args: ['@soleri/engine', '--agent', agentYaml],
+              };
+              writeF(configPath, JSON.stringify(claudeConfig, null, 2) + '\n', 'utf-8');
+              p.log.success(`Registered ${config.id} in ~/.claude.json`);
+            } catch {
+              p.log.warn(
+                'Could not auto-register — run `npx @soleri/cli install --target claude` manually.',
+              );
+            }
+
             p.note(result.summary, 'Next steps');
             p.outro('Done!');
             return;

--- a/packages/forge/src/scaffold-filetree.ts
+++ b/packages/forge/src/scaffold-filetree.ts
@@ -785,8 +785,7 @@ To export entries as files: **"Export vault entries as markdown"**
     'Next steps:',
     `  1. cd ${config.id}`,
     '  2. Review agent.yaml and customize instructions/',
-    '  3. Run: soleri install   (registers MCP server)',
-    '  4. Run: soleri dev       (watches files, auto-regenerates CLAUDE.md)',
+    '  3. Run: soleri dev       (watches files, auto-regenerates CLAUDE.md)',
     '',
     'No build step needed — this agent is ready to use.',
   ].join('\n');

--- a/src/i18n/pages/getting-started.ts
+++ b/src/i18n/pages/getting-started.ts
@@ -39,26 +39,25 @@ const content: Record<Locale, GettingStartedContent> = {
         isInstallCmd: false,
       },
       {
-        title: 'Register it in your editor',
-        text: 'From inside the new folder, register the MCP server. Claude Code, Cursor, and OpenCode are supported.',
-        code: `<span class="prompt">$</span> <span class="cmd">cd</span> <span class="arg">my-agent</span>
-<span class="prompt">$</span> <span class="cmd">npx @soleri/cli install</span> <span class="arg">--target claude</span>
-
-<span class="ok">✓</span> Detected file-tree agent
+        title: 'Open Claude Code',
+        text: 'The scaffold auto-registers your agent as an MCP server. Just open Claude Code — your agent is ready. For other editors, run the install command manually.',
+        code: `<span class="cmt"># Your agent was auto-registered during scaffold:</span>
 <span class="ok">✓</span> Registered my-agent in <span class="val">~/.claude.json</span>
-<span class="ok">✓</span> Launcher created`,
+
+<span class="cmt"># For other editors (Codex, OpenCode):</span>
+<span class="prompt">$</span> <span class="cmd">cd</span> <span class="arg">my-agent</span>
+<span class="prompt">$</span> <span class="cmd">npx @soleri/cli install</span> <span class="arg">--target codex</span>`,
         isInstallCmd: false,
       },
       {
         title: 'Run the engine',
         text: 'Start the engine while you work. It watches your agent files, regenerates CLAUDE.md on change, and keeps the knowledge engine running.',
-        code: `<span class="prompt">$</span> <span class="cmd">npx @soleri/cli dev</span>
+        code: `<span class="prompt">$</span> <span class="cmd">cd</span> <span class="arg">my-agent</span>
+<span class="prompt">$</span> <span class="cmd">npx @soleri/cli dev</span>
 
 <span class="ok">✓</span> MCP server running
 <span class="ok">✓</span> Watching agent.yaml, instructions/, workspaces/, skills/
-<span class="ok">✓</span> CLAUDE.md regenerates on change
-<span class="ok">✓</span> 3 workspaces loaded <span class="cmt">(planning, src, docs)</span>
-<span class="ok">✓</span> 7 essential skills active`,
+<span class="ok">✓</span> CLAUDE.md regenerates on change`,
         isInstallCmd: false,
       },
     ],


### PR DESCRIPTION
## Summary
- After `npm create soleri my-agent`, the agent is auto-registered in `~/.claude.json` — no manual `soleri install` step needed
- Fails gracefully with a warning if `~/.claude.json` is not writable
- Scaffold "Next steps" no longer mentions `soleri install`
- Website step 3 updated to show auto-registration

Closes #551

## Test plan
- [x] 226 CLI tests pass
- [x] 160 forge tests pass
- [x] Build passes
- [ ] Manual: `npm create soleri test-agent` on clean machine, verify `~/.claude.json` has entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent scaffolding now automatically registers the MCP server, eliminating manual registration steps.

* **Documentation**
  * Updated getting started guide to reflect the simplified setup workflow without the registration step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->