### PR TITLE
fix(cli): replace misleading install success message

### DIFF
--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -194,7 +194,7 @@ export function installClaude(agentId: string, agentDir: string, isFileTree: boo
     p.log.error(`Cannot write to ${configPath}. Check file permissions.`);
     process.exit(1);
   }
-  p.log.success(`Registered ${agentId} in ~/.claude.json`);
+  p.log.success(`Registered ${agentId} in ~/.claude.json (restart your session to load)`);
 
   // Pre-approve facade permissions so users don't hit approval prompts
   installClaudePermissions(agentId);
@@ -246,7 +246,7 @@ function installCodex(agentId: string, agentDir: string, isFileTree: boolean): v
     p.log.error(`Cannot write to ${configPath}. Check file permissions.`);
     process.exit(1);
   }
-  p.log.success(`Registered ${agentId} in ~/.codex/config.toml`);
+  p.log.success(`Registered ${agentId} in ~/.codex/config.toml (restart your session to load)`);
 }
 
 function installOpencode(agentId: string, agentDir: string, isFileTree: boolean): void {
@@ -306,7 +306,9 @@ function installOpencode(agentId: string, agentDir: string, isFileTree: boolean)
     p.log.error(`Cannot write to ${configPath}. Check file permissions.`);
     process.exit(1);
   }
-  p.log.success(`Registered ${agentId} in ~/.config/opencode/opencode.json`);
+  p.log.success(
+    `Registered ${agentId} in ~/.config/opencode/opencode.json (restart your session to load)`,
+  );
 }
 
 function escapeRegExp(s: string): string {
@@ -414,6 +416,8 @@ export function registerInstall(program: Command): void {
       // Create global launcher script
       installLauncher(ctx.agentId, ctx.agentPath);
 
-      p.log.info(`Agent ${ctx.agentId} is now available as an MCP server.`);
+      p.log.info(
+        `Install complete for ${ctx.agentId}. Restart your session to load the MCP server.`,
+      );
     });
 }


### PR DESCRIPTION
## Summary
- Replaces false "Agent X is now available as an MCP server" with factual "Install complete for X. Restart your session to load the MCP server."
- Updates per-target registration messages to include "(restart your session to load)"

Resolves #583 | Parent: #582

## Test plan
- [x] All 226 existing tests pass
- [x] Typecheck clean
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Installation and registration messages for MCP servers now include instructions to restart your session to load the newly configured server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->