### PR TITLE
feat(cli): add --verify flag for end-to-end install health check

### DIFF
--- a/packages/cli/src/__tests__/install-verify.test.ts
+++ b/packages/cli/src/__tests__/install-verify.test.ts
@@ -75,10 +75,10 @@ describe('verifyInstall', () => {
     const { verifyInstall } = await import('../commands/install.js');
     const checks = verifyInstall('test-agent', agentDir, 'claude');
 
-    const engineCheck = checks.find((c) => c.label.includes('Engine binary'));
+    const engineCheck = checks.find((c) => c.label.includes('Engine'));
     expect(engineCheck).toBeDefined();
-    // Engine resolves locally in the monorepo, so this should pass
-    expect(typeof engineCheck!.passed).toBe('boolean');
+    // Engine always resolves (local or npx fallback)
+    expect(engineCheck!.passed).toBe(true);
   });
 
   it('should check all targets when target is "all"', async () => {

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -384,11 +384,14 @@ export function verifyInstall(agentId: string, agentDir: string, target: Target)
     });
   }
 
-  // 2. Engine binary resolves locally (not via npx fallback)
+  // 2. Engine binary resolves (local or npx fallback)
   const engine = resolveEngineBin();
+  const isLocal = engine.command === 'node';
   checks.push({
-    label: 'Engine binary resolves (local)',
-    passed: engine.command === 'node',
+    label: isLocal
+      ? `Engine binary resolves (${engine.bin})`
+      : 'Engine resolves via npx (fallback)',
+    passed: true,
   });
 
   // 3. agent.yaml exists at configured path
@@ -468,6 +471,10 @@ export function registerInstall(program: Command): void {
       // Create global launcher script
       installLauncher(ctx.agentId, ctx.agentPath);
 
+      p.log.info(
+        `Install complete for ${ctx.agentId}. Restart your session to load the MCP server.`,
+      );
+
       // Run verification if --verify was passed
       if (opts?.verify) {
         const checks = verifyInstall(ctx.agentId, ctx.agentPath, target);
@@ -485,12 +492,6 @@ export function registerInstall(program: Command): void {
           process.exit(1);
         }
         p.log.success('All checks passed.');
-        return;
       }
-
-
-      p.log.info(
-        `Install complete for ${ctx.agentId}. Restart your session to load the MCP server.`,
-      );
     });
 }


### PR DESCRIPTION
## Summary
- Adds `--verify` flag to `soleri install` that checks: config exists, agent entry present, engine resolves, agent.yaml exists
- Prints pass/fail checklist, exits non-zero on failure
- Reuses existing `resolveEngineBin()` and `detectArtifacts`

Resolves #585 | Parent: #582

## Test plan
- [x] 6 new tests for verify logic
- [x] All 232 tests pass
- [x] Typecheck clean
- [x] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--verify` flag to install command that validates installation completeness across system configurations
  * Install process now exits with error code when verification checks fail, providing clear feedback on installation status

* **Tests**
  * Added comprehensive test suite to validate installation verification behavior across multiple scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->