### PR TITLE
fix(cli): make launcher generation target-aware, skip for codex/opencode

### DIFF
--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -329,7 +329,7 @@ function installLauncher(agentId: string, agentDir: string, target: Target): voi
     p.log.info('Launcher skipped: OpenCode does not have a CLI equivalent.');
     return;
   }
-  if (target === 'all') {
+  if (target === 'all' || target === 'both') {
     p.log.info('Note: Launcher is Claude-specific — other targets do not have a CLI equivalent.');
   }
 


### PR DESCRIPTION
## Summary
- `installLauncher()` now accepts `target` parameter
- Skips launcher for `codex` and `opencode` targets with explanation
- For `all`/`both` targets, creates Claude launcher with note it's Claude-specific

Resolves #586 | Parent: #582

## Test plan
- [x] All tests pass
- [x] Typecheck clean
- [x] CodeRabbit review