### PR TITLE
feat(cli): add target-aware post-install restart instructions

### DIFF
--- a/packages/cli/src/__tests__/install.test.ts
+++ b/packages/cli/src/__tests__/install.test.ts
@@ -63,6 +63,11 @@ describe('getNextStepMessage', () => {
     expect(msg).toContain('Codex');
     expect(msg).toContain('OpenCode');
   });
+
+  it('falls back to Claude instructions for unknown target', () => {
+    const msg = getNextStepMessage('unknown-target');
+    expect(msg).toContain('Claude Code');
+  });
 });
 
 describe('installClaude path normalization', () => {

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -326,6 +326,9 @@ export function getNextStepMessage(target: string): string {
     return [instructions.claude, instructions.codex, instructions.opencode].join('\n');
   }
 
+  if (!(target in instructions)) {
+    p.log.warn(`Unknown target "${target}" — defaulting to Claude instructions.`);
+  }
   return instructions[target] ?? instructions.claude;
 }
 


### PR DESCRIPTION
## Summary
- Adds `getNextStepMessage(target)` helper with host-specific restart instructions
- Claude → "Restart your Claude Code session", Codex → "Start a new Codex conversation", OpenCode → "Restart OpenCode"
- `all`/`both` targets print each host's instruction
- Warns on unknown target instead of silently falling back to Claude

Resolves #584 | Parent: #582

## Test plan
- [x] 5 new tests for `getNextStepMessage()` across all targets
- [x] All 238 tests pass
- [x] Typecheck clean
- [x] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Install command now displays target-specific next-step instructions upon successful completion, providing clearer guidance based on the selected installation target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->