### PR TITLE
fix(cli): resolve package.json from correct path in update command

### DIFF
--- a/packages/cli/src/__tests__/update.test.ts
+++ b/packages/cli/src/__tests__/update.test.ts
@@ -65,9 +65,12 @@ describe('update command', () => {
   });
 
   it('prints already-on-latest when current version matches latest', async () => {
-    // getCurrentVersion() falls back to 'unknown' in test env (no package.json in require path).
-    // Return 'unknown' from npm view to match, triggering the "already on latest" branch.
-    vi.mocked(execSync).mockReturnValue(Buffer.from('unknown\n'));
+    // getCurrentVersion() reads ../../package.json → packages/cli/package.json.
+    // Return the same version from npm view to trigger the "already on latest" branch.
+    const { createRequire } = await import('node:module');
+    const req = createRequire(import.meta.url);
+    const { version } = req('../../package.json') as { version: string };
+    vi.mocked(execSync).mockReturnValue(Buffer.from(`${version}\n`));
 
     const action = captureAction();
     await action();

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -8,7 +8,7 @@ const require = createRequire(import.meta.url);
 function getCurrentVersion(): string {
   try {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    return (require('../package.json') as { version: string }).version;
+    return (require('../../package.json') as { version: string }).version;
   } catch {
     return 'unknown';
   }


### PR DESCRIPTION
## Summary
- `getCurrentVersion()` was using `../package.json` which resolves to `dist/package.json` (doesn't exist) — always returning 'unknown'
- Fixed to `../../package.json` which correctly resolves to `packages/cli/package.json`
- `soleri update` now shows the real installed version: `Updated 9.14.1 → 9.14.2` instead of `Updated unknown → 9.14.2`

## Test plan
- [x] 245 tests pass
- [x] Typecheck clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CLI version detection to correctly identify the current installed version and properly determine update availability.

* **Tests**
  * Updated version detection tests to align with actual CLI package behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->