### PR TITLE
fix: gate project-local skill sync on agent.yaml marker

### DIFF
--- a/packages/core/src/engine/bin/agent-project.ts
+++ b/packages/core/src/engine/bin/agent-project.ts
@@ -1,0 +1,17 @@
+/**
+ * Agent project detection helpers.
+ *
+ * Extracted from soleri-engine.ts so tests can import without triggering
+ * the engine's top-level main() bootstrap.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Check whether a directory is an agent project (contains agent.yaml).
+ * Used to gate project-local skill sync so unrelated cwd's don't get polluted.
+ */
+export function isAgentProjectDir(dir: string): boolean {
+  return existsSync(join(dir, 'agent.yaml'));
+}

--- a/packages/core/src/engine/bin/agent-project.ts
+++ b/packages/core/src/engine/bin/agent-project.ts
@@ -5,13 +5,27 @@
  * the engine's top-level main() bootstrap.
  */
 
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 
 /**
- * Check whether a directory is an agent project (contains agent.yaml).
+ * Check whether a directory is an agent project (contains an agent.yaml file).
  * Used to gate project-local skill sync so unrelated cwd's don't get polluted.
+ *
+ * Requires agent.yaml to be a regular file — a directory of that name returns false.
  */
 export function isAgentProjectDir(dir: string): boolean {
-  return existsSync(join(dir, 'agent.yaml'));
+  try {
+    return statSync(join(dir, 'agent.yaml')).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check whether two agent.yaml paths refer to the same file. Accepts absolute
+ * or relative paths; normalizes via `path.resolve` before comparing.
+ */
+export function sameAgentYaml(a: string, b: string): boolean {
+  return resolve(a) === resolve(b);
 }

--- a/packages/core/src/engine/bin/soleri-engine.test.ts
+++ b/packages/core/src/engine/bin/soleri-engine.test.ts
@@ -3,11 +3,11 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { validateAgentConfig } from './validate-agent-config.js';
-import { isAgentProjectDir } from './agent-project.js';
+import { isAgentProjectDir, sameAgentYaml } from './agent-project.js';
 
 describe('validateAgentConfig', () => {
   const yamlPath = '/fake/agent.yaml';
@@ -85,5 +85,25 @@ describe('isAgentProjectDir', () => {
 
   it('returns false for non-existent paths', () => {
     expect(isAgentProjectDir(join(dir, 'does-not-exist'))).toBe(false);
+  });
+
+  it('returns false when agent.yaml is a directory, not a file', () => {
+    // existsSync() would return true for a directory — statSync().isFile() guards this.
+    mkdirSync(join(dir, 'agent.yaml'));
+    expect(isAgentProjectDir(dir)).toBe(false);
+  });
+});
+
+describe('sameAgentYaml', () => {
+  it('returns true for identical absolute paths', () => {
+    expect(sameAgentYaml('/a/b/agent.yaml', '/a/b/agent.yaml')).toBe(true);
+  });
+
+  it('returns true after normalizing relative segments', () => {
+    expect(sameAgentYaml('/a/b/../b/agent.yaml', '/a/b/agent.yaml')).toBe(true);
+  });
+
+  it('returns false for different files', () => {
+    expect(sameAgentYaml('/a/b/agent.yaml', '/x/y/agent.yaml')).toBe(false);
   });
 });

--- a/packages/core/src/engine/bin/soleri-engine.test.ts
+++ b/packages/core/src/engine/bin/soleri-engine.test.ts
@@ -7,7 +7,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { validateAgentConfig } from './validate-agent-config.js';
-import { isAgentProjectDir } from './soleri-engine.js';
+import { isAgentProjectDir } from './agent-project.js';
 
 describe('validateAgentConfig', () => {
   const yamlPath = '/fake/agent.yaml';

--- a/packages/core/src/engine/bin/soleri-engine.test.ts
+++ b/packages/core/src/engine/bin/soleri-engine.test.ts
@@ -2,8 +2,12 @@
  * Tests for soleri-engine boot-time validation.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { validateAgentConfig } from './validate-agent-config.js';
+import { isAgentProjectDir } from './soleri-engine.js';
 
 describe('validateAgentConfig', () => {
   const yamlPath = '/fake/agent.yaml';
@@ -50,5 +54,36 @@ describe('validateAgentConfig', () => {
 
   it('includes the yaml path in the error message', () => {
     expect(() => validateAgentConfig({}, yamlPath)).toThrow(yamlPath);
+  });
+});
+
+describe('isAgentProjectDir', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'soleri-engine-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns true when agent.yaml exists at the directory', () => {
+    writeFileSync(join(dir, 'agent.yaml'), 'id: test\nname: Test\n');
+    expect(isAgentProjectDir(dir)).toBe(true);
+  });
+
+  it('returns false when agent.yaml is missing', () => {
+    expect(isAgentProjectDir(dir)).toBe(false);
+  });
+
+  it('returns false for unrelated project directories', () => {
+    writeFileSync(join(dir, 'package.json'), '{}');
+    writeFileSync(join(dir, 'README.md'), '');
+    expect(isAgentProjectDir(dir)).toBe(false);
+  });
+
+  it('returns false for non-existent paths', () => {
+    expect(isAgentProjectDir(join(dir, 'does-not-exist'))).toBe(false);
   });
 });

--- a/packages/core/src/engine/bin/soleri-engine.ts
+++ b/packages/core/src/engine/bin/soleri-engine.ts
@@ -25,7 +25,7 @@ import { seedDefaultPlaybooks } from '../../playbooks/playbook-seeder.js';
 import { agentVaultPath } from '../../paths.js';
 import { checkForUpdate } from '../../update-check.js';
 import { syncSkillsToClaudeCode } from '../../skills/sync-skills.js';
-import { isAgentProjectDir } from './agent-project.js';
+import { isAgentProjectDir, sameAgentYaml } from './agent-project.js';
 import type { AgentIdentityConfig } from '../core-ops.js';
 
 // ─── Parse CLI args ───────────────────────────────────────────────────
@@ -197,13 +197,19 @@ async function main(): Promise<void> {
   );
 
   // 6b. Auto-sync skills to project-local .claude/skills/
-  // Only sync when cwd is an actual agent project (marker: agent.yaml at cwd).
-  // In user projects (e.g. unrelated repos), global skills at ~/.claude/skills/
-  // already provide discovery — project-local sync would pollute the cwd.
+  // Only sync when cwd is the same agent project this engine was launched for.
+  // Two gates:
+  //   1. cwd must contain agent.yaml (it's an agent project)
+  //   2. cwd's agent.yaml must resolve to the same path as --agent
+  // Otherwise the engine could write skills from agent A into agent B's checkout,
+  // or into an unrelated user project. Global skills at ~/.claude/skills/ cover
+  // discovery in all other cases.
   const skillsDir = join(agentDir, 'skills');
   const cwd = process.cwd();
+  const cwdAgentYamlPath = join(cwd, 'agent.yaml');
   const isAgentProject = isAgentProjectDir(cwd);
-  if (existsSync(skillsDir) && isAgentProject) {
+  const sameProject = isAgentProject && sameAgentYaml(agentYamlPath, cwdAgentYamlPath);
+  if (existsSync(skillsDir) && sameProject) {
     const syncResult = syncSkillsToClaudeCode([skillsDir], config.name as string, {
       projectRoot: cwd,
     });
@@ -219,6 +225,10 @@ async function main(): Promise<void> {
     if (syncResult.cleanedGlobal.length) {
       console.error(`${tag} Cleaned ${syncResult.cleanedGlobal.length} stale global skill(s)`);
     }
+  } else if (existsSync(skillsDir) && isAgentProject && !sameProject) {
+    console.error(
+      `${tag} Skills sync skipped: cwd agent.yaml (${cwdAgentYamlPath}) does not match --agent (${agentYamlPath}). Global skills at ~/.claude/skills/ remain active.`,
+    );
   } else if (existsSync(skillsDir) && !isAgentProject) {
     console.error(
       `${tag} Skills sync skipped: cwd is not an agent project (no agent.yaml at ${cwd}). Global skills at ~/.claude/skills/ remain active.`,

--- a/packages/core/src/engine/bin/soleri-engine.ts
+++ b/packages/core/src/engine/bin/soleri-engine.ts
@@ -27,6 +27,14 @@ import { checkForUpdate } from '../../update-check.js';
 import { syncSkillsToClaudeCode } from '../../skills/sync-skills.js';
 import type { AgentIdentityConfig } from '../core-ops.js';
 
+/**
+ * Check whether a directory is an agent project (contains agent.yaml).
+ * Used to gate project-local skill sync so unrelated cwd's don't get polluted.
+ */
+export function isAgentProjectDir(dir: string): boolean {
+  return existsSync(join(dir, 'agent.yaml'));
+}
+
 // ─── Parse CLI args ───────────────────────────────────────────────────
 
 function parseArgs(): { agentYamlPath: string } {
@@ -196,10 +204,15 @@ async function main(): Promise<void> {
   );
 
   // 6b. Auto-sync skills to project-local .claude/skills/
+  // Only sync when cwd is an actual agent project (marker: agent.yaml at cwd).
+  // In user projects (e.g. unrelated repos), global skills at ~/.claude/skills/
+  // already provide discovery — project-local sync would pollute the cwd.
   const skillsDir = join(agentDir, 'skills');
-  if (existsSync(skillsDir)) {
+  const cwd = process.cwd();
+  const isAgentProject = isAgentProjectDir(cwd);
+  if (existsSync(skillsDir) && isAgentProject) {
     const syncResult = syncSkillsToClaudeCode([skillsDir], config.name as string, {
-      projectRoot: process.cwd(),
+      projectRoot: cwd,
     });
     const total = syncResult.installed.length + syncResult.updated.length;
     if (total > 0) {
@@ -213,6 +226,10 @@ async function main(): Promise<void> {
     if (syncResult.cleanedGlobal.length) {
       console.error(`${tag} Cleaned ${syncResult.cleanedGlobal.length} stale global skill(s)`);
     }
+  } else if (existsSync(skillsDir) && !isAgentProject) {
+    console.error(
+      `${tag} Skills sync skipped: cwd is not an agent project (no agent.yaml at ${cwd}). Global skills at ~/.claude/skills/ remain active.`,
+    );
   }
 
   // 7. Load domain packs

--- a/packages/core/src/engine/bin/soleri-engine.ts
+++ b/packages/core/src/engine/bin/soleri-engine.ts
@@ -25,15 +25,8 @@ import { seedDefaultPlaybooks } from '../../playbooks/playbook-seeder.js';
 import { agentVaultPath } from '../../paths.js';
 import { checkForUpdate } from '../../update-check.js';
 import { syncSkillsToClaudeCode } from '../../skills/sync-skills.js';
+import { isAgentProjectDir } from './agent-project.js';
 import type { AgentIdentityConfig } from '../core-ops.js';
-
-/**
- * Check whether a directory is an agent project (contains agent.yaml).
- * Used to gate project-local skill sync so unrelated cwd's don't get polluted.
- */
-export function isAgentProjectDir(dir: string): boolean {
-  return existsSync(join(dir, 'agent.yaml'));
-}
 
 // ─── Parse CLI args ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Engine previously synced `soleri-*` skills into `process.cwd()/.claude/skills/` unconditionally on every startup. When the engine launched with an unrelated user project as cwd, it polluted that repo with ~44 skill folders.
- Fix: only sync project-locally when cwd contains `agent.yaml`. Otherwise skip — global skills at `~/.claude/skills/` (agent-prefixed) already cover discovery.
- Added `isAgentProjectDir()` helper + 4 unit tests.

## Test plan

- [x] `npx vitest run src/engine/bin/soleri-engine.test.ts` — 12 pass
- [x] Full core suite — 4929 pass, 0 fail
- [x] `npx tsc --noEmit` clean
- [ ] Manual: launch engine from non-agent cwd, confirm no `.claude/skills/soleri-*` dirs created
- [ ] Manual: launch engine from agent cwd (has `agent.yaml`), confirm sync still runs

## Real-world trigger

Discovered when `ernesto_core op:activate` scaffolded 44 `soleri-*` skill dirs into an unrelated Python crypto trading project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced skill synchronization to intelligently detect agent project directories and only run in valid project contexts, with improved error logging when skipped.

* **Tests**
  * Added test coverage for project directory detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->