### PR TITLE
feat(cli): add worktree-cleanup hook pack

### DIFF
--- a/packages/cli/src/hook-packs/worktree-cleanup/manifest.json
+++ b/packages/cli/src/hook-packs/worktree-cleanup/manifest.json
@@ -1,0 +1,37 @@
+{
+  "name": "worktree-cleanup",
+  "version": "1.0.0",
+  "description": "Auto-cleans stale worktree directories on session start and orphaned worktree-agent-* branches after subagent completion",
+  "hooks": [],
+  "scripts": [
+    {
+      "name": "clean-worktrees",
+      "file": "clean-worktrees.sh",
+      "targetDir": "hooks"
+    },
+    {
+      "name": "clean-worktree-branches",
+      "file": "clean-worktree-branches.sh",
+      "targetDir": "hooks"
+    }
+  ],
+  "lifecycleHooks": [
+    {
+      "event": "SessionStart",
+      "matcher": "",
+      "type": "command",
+      "command": "sh ~/.claude/hooks/clean-worktrees.sh",
+      "timeout": 10000,
+      "statusMessage": "Cleaning stale worktrees..."
+    },
+    {
+      "event": "PostToolUse",
+      "matcher": "Agent",
+      "type": "command",
+      "command": "sh ~/.claude/hooks/clean-worktree-branches.sh",
+      "timeout": 10000,
+      "statusMessage": "Cleaning orphaned worktree branches..."
+    }
+  ],
+  "scaffoldDefault": true
+}

--- a/packages/cli/src/hook-packs/worktree-cleanup/scripts/clean-worktree-branches.sh
+++ b/packages/cli/src/hook-packs/worktree-cleanup/scripts/clean-worktree-branches.sh
@@ -1,15 +1,22 @@
 #!/bin/sh
 # PostToolUse:Agent — nuke orphaned worktree-agent-* branches
 # Soleri Hook Pack: worktree-cleanup
-root=$(git rev-parse --show-toplevel 2>/dev/null || exit 0)
+root=$(git rev-parse --show-toplevel 2>/dev/null)
+[ -z "$root" ] && exit 0
 active_worktrees=$(git -C "$root" worktree list --porcelain 2>/dev/null | grep '^worktree ' | sed 's/^worktree //')
 count=0
 for branch in $(git -C "$root" branch --list 'worktree-agent-*' 2>/dev/null | tr -d ' '); do
   has_worktree=false
-  for wt in $active_worktrees; do
+  while IFS= read -r wt; do
+    [ -z "$wt" ] && continue
     wt_branch=$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null)
-    [ "$wt_branch" = "$branch" ] && has_worktree=true && break
-  done
+    if [ "$wt_branch" = "$branch" ]; then
+      has_worktree=true
+      break
+    fi
+  done <<EOF
+$active_worktrees
+EOF
   [ "$has_worktree" = "false" ] && git -C "$root" branch -D "$branch" 2>/dev/null && count=$((count + 1))
 done
 [ "$count" -gt 0 ] && echo "Cleaned $count orphaned worktree branch(es)"

--- a/packages/cli/src/hook-packs/worktree-cleanup/scripts/clean-worktree-branches.sh
+++ b/packages/cli/src/hook-packs/worktree-cleanup/scripts/clean-worktree-branches.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# PostToolUse:Agent — nuke orphaned worktree-agent-* branches
+# Soleri Hook Pack: worktree-cleanup
+root=$(git rev-parse --show-toplevel 2>/dev/null || exit 0)
+active_worktrees=$(git -C "$root" worktree list --porcelain 2>/dev/null | grep '^worktree ' | sed 's/^worktree //')
+count=0
+for branch in $(git -C "$root" branch --list 'worktree-agent-*' 2>/dev/null | tr -d ' '); do
+  has_worktree=false
+  for wt in $active_worktrees; do
+    wt_branch=$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null)
+    [ "$wt_branch" = "$branch" ] && has_worktree=true && break
+  done
+  [ "$has_worktree" = "false" ] && git -C "$root" branch -D "$branch" 2>/dev/null && count=$((count + 1))
+done
+[ "$count" -gt 0 ] && echo "Cleaned $count orphaned worktree branch(es)"
+exit 0

--- a/packages/cli/src/hook-packs/worktree-cleanup/scripts/clean-worktrees.sh
+++ b/packages/cli/src/hook-packs/worktree-cleanup/scripts/clean-worktrees.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 # SessionStart — prune stale worktree directories
 # Soleri Hook Pack: worktree-cleanup
-root=$(git rev-parse --show-toplevel 2>/dev/null || exit 0)
+root=$(git rev-parse --show-toplevel 2>/dev/null)
+[ -z "$root" ] && exit 0
 wt_dir="$root/.claude/worktrees"
 git -C "$root" worktree prune 2>/dev/null
 if [ -d "$wt_dir" ]; then
@@ -9,7 +10,7 @@ if [ -d "$wt_dir" ]; then
   for dir in "$wt_dir"/*/; do
     [ -d "$dir" ] || continue
     abs=$(cd "$dir" && pwd 2>/dev/null) || continue
-    if ! git -C "$root" worktree list --porcelain 2>/dev/null | grep -q "worktree $abs"; then
+    if ! git -C "$root" worktree list --porcelain 2>/dev/null | grep -Fxq "worktree $abs"; then
       rm -rf "$dir"
       count=$((count + 1))
     fi

--- a/packages/cli/src/hook-packs/worktree-cleanup/scripts/clean-worktrees.sh
+++ b/packages/cli/src/hook-packs/worktree-cleanup/scripts/clean-worktrees.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# SessionStart — prune stale worktree directories
+# Soleri Hook Pack: worktree-cleanup
+root=$(git rev-parse --show-toplevel 2>/dev/null || exit 0)
+wt_dir="$root/.claude/worktrees"
+git -C "$root" worktree prune 2>/dev/null
+if [ -d "$wt_dir" ]; then
+  count=0
+  for dir in "$wt_dir"/*/; do
+    [ -d "$dir" ] || continue
+    abs=$(cd "$dir" && pwd 2>/dev/null) || continue
+    if ! git -C "$root" worktree list --porcelain 2>/dev/null | grep -q "worktree $abs"; then
+      rm -rf "$dir"
+      count=$((count + 1))
+    fi
+  done
+  rmdir "$wt_dir" 2>/dev/null || true
+  [ "$count" -gt 0 ] && echo "Cleaned $count stale worktree(s)"
+fi
+exit 0


### PR DESCRIPTION
## Summary
- Ships the `worktree-cleanup` hook pack (manifest + 2 scripts) that was previously referenced in wiki docs (a18ad31) but never committed.
- `SessionStart` hook prunes stale worktree dirs under `.claude/worktrees`.
- `PostToolUse:Agent` hook deletes orphaned `worktree-agent-*` branches once their worktree is gone.
- Auto-discovered by the registry — no other wiring needed. `scaffoldDefault: true`.

## Test plan
- [ ] `soleri hooks list` shows `worktree-cleanup` as a built-in pack
- [ ] `soleri hooks add-pack worktree-cleanup` installs scripts to `~/.claude/hooks/`
- [ ] SessionStart hook prunes stale worktree dirs without error
- [ ] PostToolUse:Agent hook removes orphaned `worktree-agent-*` branches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic Git worktree cleanup operations. Stale worktrees are automatically removed at session start, and orphaned worktree branches are cleaned up following agent tool operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->