### PR TITLE
feat(core): gate session-memory auto-capture behind engine.autoOps.captureSessions

### DIFF
--- a/packages/core/src/runtime/agent-config.test.ts
+++ b/packages/core/src/runtime/agent-config.test.ts
@@ -90,6 +90,7 @@ describe('resolveAutoOpsConfig', () => {
       selfHeal: false,
       orphanReaper: false,
       staleClose: false,
+      captureSessions: false,
     });
   });
 
@@ -99,6 +100,17 @@ describe('resolveAutoOpsConfig', () => {
       selfHeal: true,
       orphanReaper: false,
       staleClose: false,
+      captureSessions: false,
+    });
+  });
+
+  it('honors captureSessions opt-in', () => {
+    expect(resolveAutoOpsConfig({ engine: { autoOps: { captureSessions: true } } })).toEqual({
+      dream: false,
+      selfHeal: false,
+      orphanReaper: false,
+      staleClose: false,
+      captureSessions: true,
     });
   });
 });

--- a/packages/core/src/runtime/agent-config.ts
+++ b/packages/core/src/runtime/agent-config.ts
@@ -12,6 +12,8 @@ export interface AgentAutoOpsConfig {
   selfHeal?: boolean;
   orphanReaper?: boolean;
   staleClose?: boolean;
+  /** When true, transcript capture hook + red-level health warnings auto-write `type=session` memories. Default false. */
+  captureSessions?: boolean;
 }
 
 export interface AgentEngineConfig {
@@ -38,6 +40,7 @@ export const DEFAULT_AUTO_OPS_CONFIG: Required<AgentAutoOpsConfig> = {
   selfHeal: false,
   orphanReaper: false,
   staleClose: false,
+  captureSessions: false,
 };
 
 export function resolveAutoOpsConfig(config: AgentConfig): Required<AgentAutoOpsConfig> {

--- a/packages/core/src/runtime/orchestrate-execution-ops.ts
+++ b/packages/core/src/runtime/orchestrate-execution-ops.ts
@@ -26,6 +26,7 @@ import {
   planStore,
   withWorkflowPreamble,
 } from './orchestrate-shared.js';
+import { loadAgentConfig, resolveAutoOpsConfig } from './agent-config.js';
 
 export interface OrchestrateExecutionContext {
   runtime: AgentRuntime;
@@ -84,6 +85,9 @@ export function createOrchestrateExecuteOp(ctx: OrchestrateExecutionContext): Op
       const useSubagent = params.subagent as boolean | undefined;
       const parallelMode = params.parallel as boolean | undefined;
       const maxConcurrentParam = params.maxConcurrent as number | undefined;
+      const autoCapture = resolveAutoOpsConfig(
+        loadAgentConfig(runtime.config.agentDir ?? ''),
+      ).captureSessions;
 
       // ── Subagent dispatch path ───────────────────────────────────
       // When subagent=true, dispatch plan tasks via SubagentDispatcher.
@@ -147,7 +151,7 @@ export function createOrchestrateExecuteOp(ctx: OrchestrateExecutionContext): Op
           payloadSize: JSON.stringify(aggregated).length,
         });
         const healthStatus = contextHealth.check();
-        const healthWarning = buildHealthWarning(healthStatus, vault);
+        const healthWarning = buildHealthWarning(healthStatus, vault, autoCapture);
 
         // Check for subagent review stage requirements from matched playbook
         const legacyPlanForReview = planner.get(planId);
@@ -228,7 +232,7 @@ export function createOrchestrateExecuteOp(ctx: OrchestrateExecutionContext): Op
           payloadSize: JSON.stringify(adapterResult).length,
         });
         const healthStatus = contextHealth.check();
-        const healthWarning = buildHealthWarning(healthStatus, vault);
+        const healthWarning = buildHealthWarning(healthStatus, vault, autoCapture);
 
         return {
           plan: { id: planId, status: 'executing' },
@@ -282,7 +286,7 @@ export function createOrchestrateExecuteOp(ctx: OrchestrateExecutionContext): Op
           payloadSize: JSON.stringify(executionResult).length,
         });
         const healthStatus = contextHealth.check();
-        const healthWarning = buildHealthWarning(healthStatus, vault);
+        const healthWarning = buildHealthWarning(healthStatus, vault, autoCapture);
 
         // Build workflow preamble for the calling agent's context
         const workflowPreamble = entry.plan.workflowPrompt
@@ -324,7 +328,7 @@ export function createOrchestrateExecuteOp(ctx: OrchestrateExecutionContext): Op
         payloadSize: JSON.stringify(plan).length,
       });
       const healthStatus = contextHealth.check();
-      const healthWarning = buildHealthWarning(healthStatus, vault);
+      const healthWarning = buildHealthWarning(healthStatus, vault, autoCapture);
 
       return {
         plan,

--- a/packages/core/src/runtime/orchestrate-shared.test.ts
+++ b/packages/core/src/runtime/orchestrate-shared.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for orchestrate-shared.ts — buildHealthWarning gating.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { buildHealthWarning } from './orchestrate-shared.js';
+import type { ContextHealthStatus } from './context-health.js';
+import type { AgentRuntime } from './types.js';
+
+function makeStatus(level: ContextHealthStatus['level']): ContextHealthStatus {
+  return {
+    level,
+    estimatedFill: level === 'red' ? 0.95 : level === 'yellow' ? 0.5 : 0.1,
+    estimatedTokens: 50_000,
+    toolCallCount: 100,
+    recommendation: `level=${level}`,
+  };
+}
+
+function makeVault(): { vault: AgentRuntime['vault']; captureMemory: ReturnType<typeof vi.fn> } {
+  const captureMemory = vi.fn();
+  const vault = { captureMemory } as unknown as AgentRuntime['vault'];
+  return { vault, captureMemory };
+}
+
+describe('buildHealthWarning', () => {
+  it('returns null when status is green regardless of autoCapture', () => {
+    const { vault, captureMemory } = makeVault();
+    expect(buildHealthWarning(makeStatus('green'), vault, true)).toBeNull();
+    expect(captureMemory).not.toHaveBeenCalled();
+  });
+
+  it('returns yellow warning without writing a session memory', () => {
+    const { vault, captureMemory } = makeVault();
+    const warning = buildHealthWarning(makeStatus('yellow'), vault, true);
+    expect(warning?.level).toBe('yellow');
+    expect(warning?.sessionCaptured).toBeUndefined();
+    expect(captureMemory).not.toHaveBeenCalled();
+  });
+
+  it('does NOT write a session memory on red when autoCapture is false', () => {
+    const { vault, captureMemory } = makeVault();
+    const warning = buildHealthWarning(makeStatus('red'), vault, false);
+    expect(warning?.level).toBe('red');
+    expect(warning?.sessionCaptured).toBe(false);
+    expect(captureMemory).not.toHaveBeenCalled();
+  });
+
+  it('writes a session memory on red when autoCapture is true', () => {
+    const { vault, captureMemory } = makeVault();
+    const warning = buildHealthWarning(makeStatus('red'), vault, true);
+    expect(warning?.level).toBe('red');
+    expect(warning?.sessionCaptured).toBe(true);
+    expect(captureMemory).toHaveBeenCalledTimes(1);
+    const call = captureMemory.mock.calls[0]?.[0] as { type: string };
+    expect(call.type).toBe('session');
+  });
+
+  it('reports sessionCaptured=false when captureMemory throws', () => {
+    const { vault, captureMemory } = makeVault();
+    captureMemory.mockImplementation(() => {
+      throw new Error('vault unavailable');
+    });
+    const warning = buildHealthWarning(makeStatus('red'), vault, true);
+    expect(warning?.sessionCaptured).toBe(false);
+  });
+});

--- a/packages/core/src/runtime/orchestrate-shared.ts
+++ b/packages/core/src/runtime/orchestrate-shared.ts
@@ -250,11 +250,14 @@ interface HealthWarning {
 
 /**
  * Build a context health warning if level is yellow or red.
- * On red: auto-triggers a session capture to vault memory.
+ * On red, auto-captures a `type=session` memory only when `autoCapture` is true
+ * (gated by `engine.autoOps.captureSessions`); otherwise the warning is returned
+ * with `sessionCaptured: false` and no row is written.
  */
 export function buildHealthWarning(
   status: ContextHealthStatus,
   vault: AgentRuntime['vault'],
+  autoCapture: boolean,
 ): HealthWarning | null {
   if (status.level === 'green') return null;
 
@@ -263,7 +266,7 @@ export function buildHealthWarning(
     recommendation: status.recommendation,
   };
 
-  if (status.level === 'red') {
+  if (status.level === 'red' && autoCapture) {
     try {
       vault.captureMemory({
         projectPath: '.',
@@ -283,6 +286,8 @@ export function buildHealthWarning(
     } catch {
       warning.sessionCaptured = false;
     }
+  } else if (status.level === 'red') {
+    warning.sessionCaptured = false;
   }
 
   return warning;

--- a/packages/core/src/transcript/capture-hook.test.ts
+++ b/packages/core/src/transcript/capture-hook.test.ts
@@ -2,8 +2,11 @@
  * Tests for capture-hook.ts — git context collection and enriched session memory.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { collectSessionGitContext } from './capture-hook.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { collectSessionGitContext, isSessionCaptureEnabled } from './capture-hook.js';
 import type { GitSessionContext } from './capture-hook.js';
 
 // Mock child_process.execFileSync
@@ -151,5 +154,42 @@ describe('collectSessionGitContext', () => {
       expect(opts.timeout).toBe(3000);
       expect(opts).toHaveProperty('encoding', 'utf-8');
     }
+  });
+});
+
+describe('isSessionCaptureEnabled', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'soleri-capture-hook-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns false when no agent dir is supplied', () => {
+    expect(isSessionCaptureEnabled(undefined)).toBe(false);
+  });
+
+  it('returns false when agent.yaml is missing', () => {
+    expect(isSessionCaptureEnabled(tempDir)).toBe(false);
+  });
+
+  it('returns false by default when autoOps.captureSessions is unset', () => {
+    writeFileSync(join(tempDir, 'agent.yaml'), 'id: ernesto\n');
+    expect(isSessionCaptureEnabled(tempDir)).toBe(false);
+  });
+
+  it('returns true only when agent.yaml opts in', () => {
+    writeFileSync(
+      join(tempDir, 'agent.yaml'),
+      `id: ernesto
+engine:
+  autoOps:
+    captureSessions: true
+`,
+    );
+    expect(isSessionCaptureEnabled(tempDir)).toBe(true);
   });
 });

--- a/packages/core/src/transcript/capture-hook.ts
+++ b/packages/core/src/transcript/capture-hook.ts
@@ -26,6 +26,7 @@ import { initializeSchema } from '../vault/vault-schema.js';
 import { captureTranscriptSession } from '../vault/vault-transcripts.js';
 import { parseTranscriptJsonl } from './jsonl-parser.js';
 import { captureMemory } from '../vault/vault-memories.js';
+import { loadAgentConfig, resolveAutoOpsConfig } from '../runtime/agent-config.js';
 
 // ── Arg Parsing ──────────────────────────────────────────────────────
 
@@ -34,6 +35,7 @@ interface CaptureArgs {
   transcriptPath: string;
   projectPath: string;
   vaultPath: string;
+  agentDir?: string;
 }
 
 function parseArgs(): CaptureArgs | null {
@@ -42,6 +44,7 @@ function parseArgs(): CaptureArgs | null {
   let transcriptPath: string | undefined;
   let projectPath: string | undefined;
   let vaultPath: string | undefined;
+  let agentDir: string | undefined;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -58,6 +61,9 @@ function parseArgs(): CaptureArgs | null {
     } else if (arg === '--vault-path' && next) {
       vaultPath = resolve(next);
       i++;
+    } else if (arg === '--agent-dir' && next) {
+      agentDir = resolve(next);
+      i++;
     }
   }
 
@@ -65,7 +71,17 @@ function parseArgs(): CaptureArgs | null {
     return null;
   }
 
-  return { sessionId, transcriptPath, projectPath, vaultPath };
+  return { sessionId, transcriptPath, projectPath, vaultPath, agentDir };
+}
+
+/**
+ * Read engine.autoOps.captureSessions from the agent's configuration.
+ * Defaults to false when no agent dir is supplied or the file is missing.
+ */
+export function isSessionCaptureEnabled(agentDir: string | undefined): boolean {
+  if (!agentDir) return false;
+  const config = loadAgentConfig(agentDir);
+  return resolveAutoOpsConfig(config).captureSessions;
 }
 
 // ── Git Context ─────────────────────────────────────────────────────
@@ -345,7 +361,7 @@ function main(): void {
     process.exit(1);
   }
 
-  const { sessionId, transcriptPath, projectPath, vaultPath } = parsed;
+  const { sessionId, transcriptPath, projectPath, vaultPath, agentDir } = parsed;
 
   // Validate transcript file exists
   if (!existsSync(transcriptPath)) {
@@ -374,15 +390,18 @@ function main(): void {
       `[soleri-capture] Captured session ${result.sessionId}: ${result.messagesStored} messages, ${result.segmentsStored} segments, ~${result.tokenEstimate} tokens`,
     );
 
-    // Auto-generate a session memory so every session is discoverable
-    // via memory_list, regardless of whether the agent called session_capture.
-    generateSessionMemory(
-      provider,
-      transcriptPath,
-      projectPath,
-      result.messagesStored,
-      result.tokenEstimate,
-    );
+    // Session-memory generation is opt-in (engine.autoOps.captureSessions).
+    // Default off — transcript capture above is the system of record; the
+    // memories table stays focused on lessons unless the operator opts in.
+    if (isSessionCaptureEnabled(agentDir)) {
+      generateSessionMemory(
+        provider,
+        transcriptPath,
+        projectPath,
+        result.messagesStored,
+        result.tokenEstimate,
+      );
+    }
   } catch (err) {
     console.error(`[soleri-capture] Error: ${err instanceof Error ? err.message : String(err)}`);
     process.exit(1);

--- a/packages/core/src/transcript/transcript-capture-hook.sh
+++ b/packages/core/src/transcript/transcript-capture-hook.sh
@@ -38,6 +38,10 @@ VAULT_PATH="${SOLERI_VAULT_PATH:-$HOME/.soleri/vault.db}"
 # Resolve project path: prefer cwd from hook payload, fall back to PWD
 PROJECT_PATH="${CWD:-$PWD}"
 
+# Optional: agent dir lets the capture script read engine.autoOps.captureSessions
+# from <agentDir>/agent.yaml. When unset, session-memory generation stays off.
+AGENT_DIR="${SOLERI_AGENT_DIR:-}"
+
 # Resolve the capture script path relative to this shell script
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 CAPTURE_SCRIPT="$SCRIPT_DIR/capture-hook.js"
@@ -54,11 +58,20 @@ if [ ! -f "$CAPTURE_SCRIPT" ]; then
 fi
 
 # Run the capture script — redirect stderr to stdout for hook logging
-node "$CAPTURE_SCRIPT" \
-  --session-id "$SESSION_ID" \
-  --transcript-path "$TRANSCRIPT_PATH" \
-  --project-path "$PROJECT_PATH" \
-  --vault-path "$VAULT_PATH" 2>&1 || true
+if [ -n "$AGENT_DIR" ]; then
+  node "$CAPTURE_SCRIPT" \
+    --session-id "$SESSION_ID" \
+    --transcript-path "$TRANSCRIPT_PATH" \
+    --project-path "$PROJECT_PATH" \
+    --vault-path "$VAULT_PATH" \
+    --agent-dir "$AGENT_DIR" 2>&1 || true
+else
+  node "$CAPTURE_SCRIPT" \
+    --session-id "$SESSION_ID" \
+    --transcript-path "$TRANSCRIPT_PATH" \
+    --project-path "$PROJECT_PATH" \
+    --vault-path "$VAULT_PATH" 2>&1 || true
+fi
 
 # Always exit 0 — never block the hook
 exit 0

--- a/packages/core/src/transcript/transcript-capture-hook.sh
+++ b/packages/core/src/transcript/transcript-capture-hook.sh
@@ -38,9 +38,11 @@ VAULT_PATH="${SOLERI_VAULT_PATH:-$HOME/.soleri/vault.db}"
 # Resolve project path: prefer cwd from hook payload, fall back to PWD
 PROJECT_PATH="${CWD:-$PWD}"
 
-# Optional: agent dir lets the capture script read engine.autoOps.captureSessions
-# from <agentDir>/agent.yaml. When unset, session-memory generation stays off.
-AGENT_DIR="${SOLERI_AGENT_DIR:-}"
+# Agent dir lets the capture script read engine.autoOps.captureSessions
+# from <agentDir>/agent.yaml. Falls back to the vault's parent directory,
+# which matches Soleri's standard install layout (~/.soleri/vault.db).
+# Session-memory generation stays off when no agent.yaml is found there.
+AGENT_DIR="${SOLERI_AGENT_DIR:-$(dirname "$VAULT_PATH")}"
 
 # Resolve the capture script path relative to this shell script
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
@@ -58,20 +60,12 @@ if [ ! -f "$CAPTURE_SCRIPT" ]; then
 fi
 
 # Run the capture script — redirect stderr to stdout for hook logging
-if [ -n "$AGENT_DIR" ]; then
-  node "$CAPTURE_SCRIPT" \
-    --session-id "$SESSION_ID" \
-    --transcript-path "$TRANSCRIPT_PATH" \
-    --project-path "$PROJECT_PATH" \
-    --vault-path "$VAULT_PATH" \
-    --agent-dir "$AGENT_DIR" 2>&1 || true
-else
-  node "$CAPTURE_SCRIPT" \
-    --session-id "$SESSION_ID" \
-    --transcript-path "$TRANSCRIPT_PATH" \
-    --project-path "$PROJECT_PATH" \
-    --vault-path "$VAULT_PATH" 2>&1 || true
-fi
+node "$CAPTURE_SCRIPT" \
+  --session-id "$SESSION_ID" \
+  --transcript-path "$TRANSCRIPT_PATH" \
+  --project-path "$PROJECT_PATH" \
+  --vault-path "$VAULT_PATH" \
+  --agent-dir "$AGENT_DIR" 2>&1 || true
 
 # Always exit 0 — never block the hook
 exit 0

--- a/packages/forge/src/agent-schema.ts
+++ b/packages/forge/src/agent-schema.ts
@@ -73,9 +73,16 @@ const AutoOpsConfigSchema = z
     selfHeal: z.boolean().optional().default(false),
     orphanReaper: z.boolean().optional().default(false),
     staleClose: z.boolean().optional().default(false),
+    captureSessions: z.boolean().optional().default(false),
   })
   .optional()
-  .default({ dream: false, selfHeal: false, orphanReaper: false, staleClose: false });
+  .default({
+    dream: false,
+    selfHeal: false,
+    orphanReaper: false,
+    staleClose: false,
+    captureSessions: false,
+  });
 
 /** Engine configuration */
 const EngineConfigSchema = z.object({
@@ -240,7 +247,13 @@ export const AgentYamlSchema = z.object({
   /** Knowledge engine configuration */
   engine: EngineConfigSchema.optional().default({
     learning: true,
-    autoOps: { dream: false, selfHeal: false, orphanReaper: false, staleClose: false },
+    autoOps: {
+      dream: false,
+      selfHeal: false,
+      orphanReaper: false,
+      staleClose: false,
+      captureSessions: false,
+    },
   }),
 
   // ─── Vault Connections ──────────────────────────

--- a/packages/forge/src/agent-schema.ts
+++ b/packages/forge/src/agent-schema.ts
@@ -60,7 +60,13 @@ const CompactionPolicySchema = z.object({
     .optional(),
 });
 
-/** Session-start maintenance ops. All default off; opt in under engine.autoOps. */
+/**
+ * Session-start maintenance ops. All default off; opt in under engine.autoOps.
+ *
+ * Default value matches the full output type — Zod v4 rejects `.default({})`
+ * on object schemas whose inner fields have their own defaults
+ * (vault entry: typescript-1776088772668-p52eqp).
+ */
 const AutoOpsConfigSchema = z
   .object({
     dream: z.boolean().optional().default(false),
@@ -69,7 +75,7 @@ const AutoOpsConfigSchema = z
     staleClose: z.boolean().optional().default(false),
   })
   .optional()
-  .default({});
+  .default({ dream: false, selfHeal: false, orphanReaper: false, staleClose: false });
 
 /** Engine configuration */
 const EngineConfigSchema = z.object({
@@ -232,7 +238,10 @@ export const AgentYamlSchema = z.object({
 
   // ─── Engine ─────────────────────────────────────
   /** Knowledge engine configuration */
-  engine: EngineConfigSchema.optional().default({ learning: true }),
+  engine: EngineConfigSchema.optional().default({
+    learning: true,
+    autoOps: { dream: false, selfHeal: false, orphanReaper: false, staleClose: false },
+  }),
 
   // ─── Vault Connections ──────────────────────────
   /** Link to external vaults for shared knowledge */


### PR DESCRIPTION
## Summary

Closes #801. Part of #794 (Wave 2 — measurement fixes).

Disables session-memory auto-capture by default. Two paths gated:

1. **Transcript capture hook** (the dominant noise source) — `capture-hook.ts:generateSessionMemory()` only fires when `engine.autoOps.captureSessions: true`. The hook reads agent config via a new `--agent-dir` arg; the shell wrapper defaults that arg to `dirname($VAULT_PATH)` (matches Soleri's default `~/.soleri/vault.db` install layout) and lets `$SOLERI_AGENT_DIR` override it. Transcript itself is still captured (it's the system of record).
2. **Red-level health warning** — `buildHealthWarning()` now takes `autoCapture`. When false, the red branch sets `sessionCaptured: false` and writes nothing.

`engine.autoOps.captureSessions` joins the existing `dream`, `selfHeal`, `orphanReaper`, `staleClose` opt-in flags introduced in #796 — mirrored in both `@soleri/core` (`AgentAutoOpsConfig`) and `@soleri/forge` (`AutoOpsConfigSchema`) so the field round-trips through scaffolding without being silently stripped.

No data migration. Existing 4322 `type=session` rows in `memories` are left alone — this stops the bleeding only.

## Test plan

- [x] `npx oxlint` on changed files — 0 warnings, 0 errors
- [x] `npm --workspace=@soleri/core test -- --run` — 5002 / 5003 pass (1 flaky perf test in `vault-scaling` passes in isolation, pre-existing)
- [x] `npm --workspace=@soleri/forge test -- --run` — 173 / 173 pass
- [x] New tests cover: no agent dir → off; agent.yaml without flag → off; opt-in → on; red+autoCapture=false → no captureMemory; red+autoCapture=true → captureMemory called
- [x] Forge scaffold-filetree tests still emit only opted-in flags (existing coverage)
