### PR TITLE
feat(core/planning): add gradeMinTaskCount to skip grade gate on trivial plans

### DIFF
--- a/packages/core/src/planning/planner-types.ts
+++ b/packages/core/src/planning/planner-types.ts
@@ -299,4 +299,10 @@ export interface PlannerOptions {
   executingTtlMs?: number;
   /** TTL in ms for draft/approved plans in closeStale(). Default: 30 min (1800000). */
   draftTtlMs?: number;
+  /**
+   * Plans with fewer tasks than this skip the grade gate on `approve()`. The
+   * 8-pass gap analysis is wrong-sized for trivial plans; this lets small work
+   * approve without round-tripping through grading. Default: 5.
+   */
+  gradeMinTaskCount?: number;
 }

--- a/packages/core/src/planning/planner.test.ts
+++ b/packages/core/src/planning/planner.test.ts
@@ -227,13 +227,18 @@ describe('Planner', () => {
     });
 
     it('should reject approval when grade is below A', () => {
-      const plan = planner.create({
+      // gradeMinTaskCount: 0 keeps the gate live for sub-threshold plans;
+      // this test asserts the grading mechanic, not size-gating (#802).
+      const strictPlanner = new Planner(join(tempDir, 'strict-plans.json'), {
+        gradeMinTaskCount: 0,
+      });
+      const plan = strictPlanner.create({
         objective: 'Bad plan',
         scope: 'test',
       });
-      const check = planner.grade(plan.id);
+      const check = strictPlanner.grade(plan.id);
       expect(check.score).toBeLessThan(90);
-      expect(() => planner.approve(plan.id)).toThrow(PlanGradeRejectionError);
+      expect(() => strictPlanner.approve(plan.id)).toThrow(PlanGradeRejectionError);
     });
 
     it('should approve a plan with no grade check (backward compatibility)', () => {
@@ -263,10 +268,13 @@ describe('Planner', () => {
     });
 
     it('should reject with PlanGradeRejectionError containing gap details', () => {
-      const plan = planner.create({ objective: '', scope: '' });
-      const check = planner.grade(plan.id);
+      const strictPlanner = new Planner(join(tempDir, 'strict-detail-plans.json'), {
+        gradeMinTaskCount: 0,
+      });
+      const plan = strictPlanner.create({ objective: '', scope: '' });
+      const check = strictPlanner.grade(plan.id);
       try {
-        planner.approve(plan.id);
+        strictPlanner.approve(plan.id);
         expect.unreachable('Should have thrown');
       } catch (err) {
         expect(err).toBeInstanceOf(PlanGradeRejectionError);
@@ -282,9 +290,11 @@ describe('Planner', () => {
     it('should respect grading performed by another planner instance', () => {
       const strictPlanner = new Planner(join(tempDir, 'shared-plans.json'), {
         minGradeForApproval: 'A',
+        gradeMinTaskCount: 0,
       });
       const gradingPlanner = new Planner(join(tempDir, 'shared-plans.json'), {
         minGradeForApproval: 'A',
+        gradeMinTaskCount: 0,
       });
       const plan = strictPlanner.create({ objective: '', scope: '' });
 
@@ -292,6 +302,49 @@ describe('Planner', () => {
 
       expect(check.grade).toBe('F');
       expect(() => strictPlanner.approve(plan.id)).toThrow(PlanGradeRejectionError);
+    });
+
+    it('should skip grade gate for plans below gradeMinTaskCount (default 5)', () => {
+      // Default threshold is 5 — empty plan with bad grade still approves.
+      const plan = planner.create({ objective: 'Trivial work', scope: 'test' });
+      const check = planner.grade(plan.id);
+      expect(check.score).toBeLessThan(90);
+      const approved = planner.approve(plan.id);
+      expect(approved.status).toBe('approved');
+    });
+
+    it('should still gate plans at or above gradeMinTaskCount with low grades', () => {
+      const plan = planner.create({
+        objective: 'Five-task work',
+        scope: 'test',
+        tasks: [
+          { title: 'T1', description: 'one' },
+          { title: 'T2', description: 'two' },
+          { title: 'T3', description: 'three' },
+          { title: 'T4', description: 'four' },
+          { title: 'T5', description: 'five' },
+        ],
+      });
+      const check = planner.grade(plan.id);
+      expect(check.score).toBeLessThan(90);
+      expect(() => planner.approve(plan.id)).toThrow(PlanGradeRejectionError);
+    });
+
+    it('should honor a custom gradeMinTaskCount threshold', () => {
+      const tightPlanner = new Planner(join(tempDir, 'tight-plans.json'), {
+        gradeMinTaskCount: 2,
+      });
+      const plan = tightPlanner.create({
+        objective: 'Two-task work',
+        scope: 'test',
+        tasks: [
+          { title: 'T1', description: 'one' },
+          { title: 'T2', description: 'two' },
+        ],
+      });
+      const check = tightPlanner.grade(plan.id);
+      expect(check.score).toBeLessThan(90);
+      expect(() => tightPlanner.approve(plan.id)).toThrow(PlanGradeRejectionError);
     });
   });
 

--- a/packages/core/src/planning/planner.ts
+++ b/packages/core/src/planning/planner.ts
@@ -57,6 +57,7 @@ export class Planner {
   private minGradeForApproval: PlanGrade;
   private executingTtlMs: number;
   private draftTtlMs: number;
+  private gradeMinTaskCount: number;
 
   constructor(filePath: string, options?: GapAnalysisOptions | PlannerOptions) {
     this.filePath = filePath;
@@ -65,18 +66,21 @@ export class Planner {
       ('minGradeForApproval' in options ||
         'executingTtlMs' in options ||
         'draftTtlMs' in options ||
-        'gapOptions' in options)
+        'gapOptions' in options ||
+        'gradeMinTaskCount' in options)
     ) {
       const opts = options as PlannerOptions;
       this.gapOptions = opts.gapOptions;
       this.minGradeForApproval = opts.minGradeForApproval ?? 'A';
       this.executingTtlMs = opts.executingTtlMs ?? 24 * 60 * 60 * 1000;
       this.draftTtlMs = opts.draftTtlMs ?? 30 * 60 * 1000;
+      this.gradeMinTaskCount = opts.gradeMinTaskCount ?? 5;
     } else {
       this.gapOptions = options as GapAnalysisOptions | undefined;
       this.minGradeForApproval = 'A';
       this.executingTtlMs = 24 * 60 * 60 * 1000;
       this.draftTtlMs = 30 * 60 * 1000;
+      this.gradeMinTaskCount = 5;
     }
     this.store = this.load();
   }
@@ -238,7 +242,11 @@ export class Planner {
   approve(planId: string): Plan {
     const plan = this.requirePlan(planId);
     const check = plan.latestCheck;
-    if (check && check.score < gradeToMinScore(this.minGradeForApproval)) {
+    // Trivial plans skip the grade gate — 8-pass gap analysis is wrong-sized
+    // for work below `gradeMinTaskCount` tasks. The gate still fires for any
+    // plan at or above the threshold.
+    const meetsTaskThreshold = plan.tasks.length >= this.gradeMinTaskCount;
+    if (check && meetsTaskThreshold && check.score < gradeToMinScore(this.minGradeForApproval)) {
       throw new PlanGradeRejectionError(
         check.grade,
         check.score,


### PR DESCRIPTION
## Summary

Closes #802. Part of #794 (Wave 3 — gate tuning).

Adds `PlannerOptions.gradeMinTaskCount` (default `5`). Plans below the threshold skip the grade gate on `approve()`; plans at or above the threshold continue through the existing 8-pass gap analysis + `minGradeForApproval` check.

The grading machinery is unchanged — `latestCheck` still gets populated by `grade()`, `PlanGradeRejectionError` still surfaces gaps when fired. Only the gate condition in `approve()` gains a task-count precondition.

Three pre-existing tests asserted grade rejection on empty/sparse plans; they now construct their own `Planner` with `gradeMinTaskCount: 0` to keep testing what they were testing (the grading mechanic, not the size-gate).

## Test plan

- [x] `npx oxlint` — 0 warnings, 0 errors
- [x] `npm --workspace=@soleri/core test -- --run` — 4996 / 4996 pass
- [x] New tests cover: default 5 skips trivial plan; 5+ tasks still gate; custom threshold honored
