### PR TITLE
feat(core): make playbook task injection opt-in via create_plan injectTasks

### DIFF
--- a/packages/core/src/runtime/facades/plan-facade.test.ts
+++ b/packages/core/src/runtime/facades/plan-facade.test.ts
@@ -200,7 +200,8 @@ describe('plan-facade', () => {
     } as unknown as AgentRuntime;
     const gatedOps = captureOps(createPlanFacadeOps(gatedRuntime));
 
-    // Create a plan — TDD playbook will be matched and session started
+    // Create a plan — TDD playbook will be matched and session started.
+    // injectTasks: true preserves prior auto-injection behavior under test.
     const createResult = await executeOp(gatedOps, 'create_plan', {
       objective: 'Implement feature X',
       scope: 'test',
@@ -210,6 +211,7 @@ describe('plan-facade', () => {
         { approach: 'A', pros: ['x'], cons: ['y'], rejected_reason: 'z' },
         { approach: 'B', pros: ['a'], cons: ['b'], rejected_reason: 'c' },
       ],
+      injectTasks: true,
     });
     const plan = (createResult.data as Record<string, unknown>).plan as Record<string, unknown>;
     const planId = plan.id as string;
@@ -436,6 +438,64 @@ describe('plan-facade', () => {
     expect(result.success).toBe(true);
     const data = result.data as Record<string, unknown>;
     expect(data.quotaWarning).toBeUndefined();
+  });
+
+  // ─── create_plan playbook injection opt-in ─────────────────────
+
+  it('create_plan does NOT inject playbook tasks by default', async () => {
+    const userTask = { title: 'User task', description: 'Only my task' };
+    const result = await executeOp(ops, 'create_plan', {
+      objective: 'Implement feature with TDD red-green-refactor cycle',
+      scope: 'packages/core',
+      tasks: [userTask],
+    });
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      plan: { tasks: Array<{ title: string }>; playbookMatch?: unknown };
+      playbook: { label: string; tasksInjected: number; sessionId: string | null } | null;
+    };
+    // Playbook may match (metadata still surfaced) but tasks are not injected
+    expect(data.plan.tasks.map((t) => t.title)).toEqual([userTask.title]);
+    if (data.playbook) {
+      expect(data.playbook.tasksInjected).toBe(0);
+      expect(data.playbook.sessionId).toBeNull();
+    }
+  });
+
+  it('create_plan injects playbook tasks when injectTasks=true', async () => {
+    const playbookExecutor = new PlaybookExecutor();
+    const plansPath = join(tmpdir(), `plan-inject-${Date.now()}.json`);
+    const planner = new Planner(plansPath);
+    const brain = new Brain(vault);
+    const injectRuntime = {
+      vault,
+      planner,
+      brain,
+      brainIntelligence: new BrainIntelligence(vault, brain),
+      curator: new Curator(vault, brain),
+      linkManager: null,
+      chainRunner: new ChainRunner(vault.getProvider()),
+      playbookExecutor,
+    } as unknown as AgentRuntime;
+    const injectOps = captureOps(createPlanFacadeOps(injectRuntime));
+
+    const userTask = { title: 'User task', description: 'Only my task' };
+    const result = await executeOp(injectOps, 'create_plan', {
+      objective: 'Implement feature with TDD red-green-refactor cycle',
+      scope: 'packages/core',
+      tasks: [userTask],
+      injectTasks: true,
+    });
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      plan: { tasks: Array<{ title: string }> };
+      playbook: { label: string; tasksInjected: number; sessionId: string | null } | null;
+    };
+    // Playbook injection ran — at least one playbook-derived task plus the user task
+    expect(data.plan.tasks.length).toBeGreaterThan(1);
+    expect(data.playbook).not.toBeNull();
+    expect(data.playbook!.tasksInjected).toBeGreaterThan(0);
+    expect(data.playbook!.sessionId).not.toBeNull();
   });
 
   // ─── create_plan vault enrichment ─────────────────────────────

--- a/packages/core/src/runtime/facades/plan-facade.ts
+++ b/packages/core/src/runtime/facades/plan-facade.ts
@@ -51,6 +51,15 @@ export function createPlanFacadeOps(runtime: AgentRuntime): OpDefinition[] {
           )
           .optional()
           .describe('Rejected alternative approaches — plans with 2+ alternatives score higher'),
+        injectTasks: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            'When true, matched playbook task templates are injected into the plan and a ' +
+              'playbook executor session starts. Default false — playbookMatch metadata is ' +
+              'still returned, but no tasks are injected and no gates are imposed unless asked.',
+          ),
       }),
       handler: async (params) => {
         const objective = params.objective as string;
@@ -72,8 +81,10 @@ export function createPlanFacadeOps(runtime: AgentRuntime): OpDefinition[] {
           // Vault search failed — proceed without enrichment
         }
 
-        // Playbook matching: inject task templates + start executor session
+        // Playbook matching: metadata is always surfaced; task injection +
+        // executor gates only fire when the caller passes injectTasks=true.
         const userTasks = (params.tasks as Array<{ title: string; description: string }>) ?? [];
+        const injectTasks = (params.injectTasks as boolean | undefined) ?? false;
         const matchResult = matchPlaybooks('BUILD', objective);
         const playbook = matchResult.playbook;
         const playbookTasks: Array<{ title: string; description: string }> = [];
@@ -87,16 +98,18 @@ export function createPlanFacadeOps(runtime: AgentRuntime): OpDefinition[] {
             domainId: playbook.domain?.id,
           };
 
-          // Inject task templates (before-implementation first, then user tasks)
-          for (const tmpl of playbook.mergedTasks) {
-            const title = tmpl.titleTemplate.replace('{objective}', objective);
-            playbookTasks.push({ title, description: tmpl.acceptanceCriteria.join('\n') });
-          }
+          if (injectTasks) {
+            // Inject task templates (before-implementation first, then user tasks)
+            for (const tmpl of playbook.mergedTasks) {
+              const title = tmpl.titleTemplate.replace('{objective}', objective);
+              playbookTasks.push({ title, description: tmpl.acceptanceCriteria.join('\n') });
+            }
 
-          // Start executor session to track gate enforcement
-          if (runtime.playbookExecutor) {
-            const startResult = runtime.playbookExecutor.start(playbook);
-            playbookSessionId = startResult.sessionId;
+            // Start executor session to track gate enforcement
+            if (runtime.playbookExecutor) {
+              const startResult = runtime.playbookExecutor.start(playbook);
+              playbookSessionId = startResult.sessionId;
+            }
           }
         }
 


### PR DESCRIPTION
## Summary

Closes #803. Part of #794 (Wave 3 — gate tuning).

Adds `injectTasks` (default `false`) to the `create_plan` op schema. When omitted, matched playbook *metadata* still appears in `plan.playbookMatch` and the response `playbook` envelope, but no task templates are appended to the plan and no playbook executor session starts (no gates imposed). Callers that depend on auto-injection now opt in with `injectTasks: true`.

The audit observation behind this: playbook injection was adding 3–5 generic tasks ("deploy", "test in production", "create PR") to ~80% of plans regardless of work type. Default-off keeps the matching machinery surfaced so callers can still see what was matched, but the ceremony only fires on explicit ask.

The existing `update_task` TDD-gate test is updated to pass `injectTasks: true` so it still exercises gate enforcement. Two new tests cover both branches of the gate.

## Test plan

- [x] `npx oxlint` — 0 warnings, 0 errors
- [x] `npm --workspace=@soleri/core test -- --run plan-facade` — 31 / 31 pass
- [x] Full core suite — 4994 / 4995 (1 pre-existing flaky perf test in `vault-scaling` passes in isolation)
- [x] New tests cover: default → no injection, no session; `injectTasks: true` → tasks injected and session started
