### PR TITLE
fix(forge): provide typed Zod v4 defaults to unblock CI build

### DIFF
--- a/packages/forge/src/agent-schema.ts
+++ b/packages/forge/src/agent-schema.ts
@@ -60,7 +60,13 @@ const CompactionPolicySchema = z.object({
     .optional(),
 });
 
-/** Session-start maintenance ops. All default off; opt in under engine.autoOps. */
+/**
+ * Session-start maintenance ops. All default off; opt in under engine.autoOps.
+ *
+ * Default value matches the full output type — Zod v4 rejects `.default({})`
+ * on object schemas whose inner fields have their own defaults
+ * (vault entry: typescript-1776088772668-p52eqp).
+ */
 const AutoOpsConfigSchema = z
   .object({
     dream: z.boolean().optional().default(false),
@@ -69,7 +75,7 @@ const AutoOpsConfigSchema = z
     staleClose: z.boolean().optional().default(false),
   })
   .optional()
-  .default({});
+  .default({ dream: false, selfHeal: false, orphanReaper: false, staleClose: false });
 
 /** Engine configuration */
 const EngineConfigSchema = z.object({
@@ -232,7 +238,10 @@ export const AgentYamlSchema = z.object({
 
   // ─── Engine ─────────────────────────────────────
   /** Knowledge engine configuration */
-  engine: EngineConfigSchema.optional().default({ learning: true }),
+  engine: EngineConfigSchema.optional().default({
+    learning: true,
+    autoOps: { dream: false, selfHeal: false, orphanReaper: false, staleClose: false },
+  }),
 
   // ─── Vault Connections ──────────────────────────
   /** Link to external vaults for shared knowledge */


### PR DESCRIPTION
## Summary

Unblocks CI on every PR (and `npm run build` on main). Pre-existing chronic build break — `tsc` (emit mode) rejects `AutoOpsConfigSchema.default({})` and the `engine` slot's `default({ learning: true })` because Zod v4 requires `.default()` values to match the full output type, not the input type. `tsc --noEmit` was permissive enough to miss this; CI's `npm run build` runs strict `tsc`.

Fix is a one-file two-line edit:
- `AutoOpsConfigSchema` gets a typed default with all 4 flags `false`
- `engine` field defaults now include `autoOps` alongside `learning`

This is the exact gotcha already documented in vault entry `typescript-1776088772668-p52eqp`. Should land first; PRs #808/#809/#810/#811 will go green on rebase once this is in.

## Test plan

- [x] `npm --workspace=@soleri/forge run build` — clean
- [x] `npm run build --workspaces --if-present` — all packages build
- [x] `npm --workspace=@soleri/forge test -- --run` — 173 / 173 pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default configuration handling for automation operations to initialize explicit default values instead of empty defaults.
  * Enhanced documentation for session-start maintenance operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->