### PR TITLE
fix(e2e): bypass orchestrate_plan trivial-task fast-path to unblock CI

### DIFF
--- a/e2e/agent-simulation.test.ts
+++ b/e2e/agent-simulation.test.ts
@@ -955,6 +955,8 @@ describe('Agent Simulation: First Week', () => {
 
   describe('Day 7: Orchestration & Validation', () => {
     it('42. Orchestrate plan — full pipeline', async () => {
+      // 4 tasks → above the trivial-task fast-path threshold (#795), so the
+      // plan stays in draft for the explicit approve_plan call in test 43.
       const res = await op('orchestrate', 'orchestrate_plan', {
         prompt: 'Add loading skeleton screens to all data-fetching pages',
         scope: 'Frontend UX improvement',
@@ -964,6 +966,8 @@ describe('Agent Simulation: First Week', () => {
             description: 'Reusable skeleton with pulse animation',
           },
           { title: 'Add to dashboard page', description: 'Replace spinner with skeleton' },
+          { title: 'Add to settings page', description: 'Replace spinner with skeleton' },
+          { title: 'Add to feed page', description: 'Replace spinner with skeleton' },
         ],
       });
 

--- a/e2e/curator-brain-governance.test.ts
+++ b/e2e/curator-brain-governance.test.ts
@@ -643,6 +643,8 @@ describe('E2E: curator-brain-governance', () => {
 
   it('orchestrate: plan → execute → complete lifecycle', async () => {
     // Plan
+    // 4 tasks → above the trivial-task fast-path threshold (#795), so the
+    // plan stays in draft for the explicit approve_plan call below.
     const planRes = await callOp(`${AGENT_ID}_orchestrate`, 'orchestrate_plan', {
       objective: 'Test the orchestration pipeline',
       scope: 'E2E testing scope',
@@ -650,6 +652,8 @@ describe('E2E: curator-brain-governance', () => {
       tasks: [
         { title: 'Step 1', description: 'First orchestrated step' },
         { title: 'Step 2', description: 'Second orchestrated step' },
+        { title: 'Step 3', description: 'Third orchestrated step' },
+        { title: 'Step 4', description: 'Fourth orchestrated step' },
       ],
     });
     expect(planRes.success).toBe(true);

--- a/e2e/full-pipeline.test.ts
+++ b/e2e/full-pipeline.test.ts
@@ -458,10 +458,17 @@ describe('E2E: full-pipeline', () => {
       });
       expect(result.classification).toBe('complex');
 
-      // Create plan via orchestrate
+      // Create plan via orchestrate — pass 4 tasks to bypass the trivial-task
+      // fast-path (#795) so the plan stays in draft for the explicit approve.
       const plan = await callOp(`${AGENT_ID}_orchestrate`, 'orchestrate_plan', {
         prompt: 'add authentication to all API endpoints',
         projectPath: plannerDir,
+        tasks: [
+          { title: 'Wire JWT middleware', description: 'Add JWT verification middleware' },
+          { title: 'Apply to user routes', description: 'Protect /users/* endpoints' },
+          { title: 'Apply to admin routes', description: 'Protect /admin/* endpoints' },
+          { title: 'Add unit tests', description: 'Cover middleware happy and error paths' },
+        ],
       });
       expect(plan.success).toBe(true);
       const planData = plan.data as { plan: { id: string }; flow: { intent: string } };

--- a/e2e/planning-orchestration.test.ts
+++ b/e2e/planning-orchestration.test.ts
@@ -354,6 +354,8 @@ describe('E2E: planning-orchestration', () => {
     let sessionId: string;
 
     it('orchestrate_plan should return plan with intent and flow info', async () => {
+      // 4 tasks → above the trivial-task fast-path threshold (#795), so the
+      // plan stays in draft for the explicit approve_plan call below.
       const res = await callOp(orchestrateFacade, 'orchestrate_plan', {
         prompt: 'Build a notification service that sends emails and push notifications',
         projectPath: workDir,
@@ -366,6 +368,14 @@ describe('E2E: planning-orchestration', () => {
           {
             title: 'Implement email sender',
             description: 'SMTP integration for email notifications',
+          },
+          {
+            title: 'Implement push sender',
+            description: 'APNs/FCM integration for mobile push notifications',
+          },
+          {
+            title: 'Add delivery retry queue',
+            description: 'Persist failed deliveries and retry with exponential backoff',
           },
         ],
       });


### PR DESCRIPTION
## Summary

Fixes the chronic E2E test failures that have blocked CI on `main` since 2026-05-01 (the day Epic #794 task 1 / commit `972664d` landed). Net effect: unblocks the merge train for #808, #809, #810, #811, #812, #813, plus any future PR.

**Root cause:** `972664d feat(core/planning): add task-size fast-path gate` made `orchestrate_plan` auto-approve and auto-execute when the prompt is under 1000 characters AND `tasks.length <= 3`. Five E2E tests across 4 files were written before that change, calling `orchestrate_plan` with small task lists and then asserting an explicit `approve_plan` succeeds. The plan is already in `executing` state by then, so `planner.approve()` throws `Invalid transition: 'executing' -> 'approved'` and the call envelope returns `success: false`.

**Fix:** extend each affected `orchestrate_plan` call with a 4th task (or 4-task list when the original passed none) to push past the fast-path threshold. Preserves each test's original intent of exercising the full `draft -> approve -> execute` lifecycle. The fast-path itself is exercised by the unit tests added in `972664d`.

## Test plan

- [x] `npm run test:e2e` — **917 / 917 pass** (was 5 failing before the fix)
  - Light suite: 27/27 test files, 825/825 tests
  - Heavy suite: 4/4 test files, 92/92 tests

## Files

- `e2e/agent-simulation.test.ts` — Day 7 test 42 (sets up the plan test 43 then approves)
- `e2e/curator-brain-governance.test.ts` — orchestrate plan/execute/complete lifecycle
- `e2e/full-pipeline.test.ts` — "complex task" assess -> plan -> complete
- `e2e/planning-orchestration.test.ts` — Journey 3 orchestrate_execute tracking
