### PR TITLE
fix(ci): combine Zod + oxfmt + E2E unblockers into single PR

### DIFF
--- a/e2e/agent-simulation.test.ts
+++ b/e2e/agent-simulation.test.ts
@@ -955,6 +955,8 @@ describe('Agent Simulation: First Week', () => {
 
   describe('Day 7: Orchestration & Validation', () => {
     it('42. Orchestrate plan — full pipeline', async () => {
+      // 4 tasks → above the trivial-task fast-path threshold (#795), so the
+      // plan stays in draft for the explicit approve_plan call in test 43.
       const res = await op('orchestrate', 'orchestrate_plan', {
         prompt: 'Add loading skeleton screens to all data-fetching pages',
         scope: 'Frontend UX improvement',
@@ -964,6 +966,8 @@ describe('Agent Simulation: First Week', () => {
             description: 'Reusable skeleton with pulse animation',
           },
           { title: 'Add to dashboard page', description: 'Replace spinner with skeleton' },
+          { title: 'Add to settings page', description: 'Replace spinner with skeleton' },
+          { title: 'Add to feed page', description: 'Replace spinner with skeleton' },
         ],
       });
 

--- a/e2e/curator-brain-governance.test.ts
+++ b/e2e/curator-brain-governance.test.ts
@@ -643,6 +643,8 @@ describe('E2E: curator-brain-governance', () => {
 
   it('orchestrate: plan → execute → complete lifecycle', async () => {
     // Plan
+    // 4 tasks → above the trivial-task fast-path threshold (#795), so the
+    // plan stays in draft for the explicit approve_plan call below.
     const planRes = await callOp(`${AGENT_ID}_orchestrate`, 'orchestrate_plan', {
       objective: 'Test the orchestration pipeline',
       scope: 'E2E testing scope',
@@ -650,6 +652,8 @@ describe('E2E: curator-brain-governance', () => {
       tasks: [
         { title: 'Step 1', description: 'First orchestrated step' },
         { title: 'Step 2', description: 'Second orchestrated step' },
+        { title: 'Step 3', description: 'Third orchestrated step' },
+        { title: 'Step 4', description: 'Fourth orchestrated step' },
       ],
     });
     expect(planRes.success).toBe(true);

--- a/e2e/full-pipeline.test.ts
+++ b/e2e/full-pipeline.test.ts
@@ -458,10 +458,17 @@ describe('E2E: full-pipeline', () => {
       });
       expect(result.classification).toBe('complex');
 
-      // Create plan via orchestrate
+      // Create plan via orchestrate — pass 4 tasks to bypass the trivial-task
+      // fast-path (#795) so the plan stays in draft for the explicit approve.
       const plan = await callOp(`${AGENT_ID}_orchestrate`, 'orchestrate_plan', {
         prompt: 'add authentication to all API endpoints',
         projectPath: plannerDir,
+        tasks: [
+          { title: 'Wire JWT middleware', description: 'Add JWT verification middleware' },
+          { title: 'Apply to user routes', description: 'Protect /users/* endpoints' },
+          { title: 'Apply to admin routes', description: 'Protect /admin/* endpoints' },
+          { title: 'Add unit tests', description: 'Cover middleware happy and error paths' },
+        ],
       });
       expect(plan.success).toBe(true);
       const planData = plan.data as { plan: { id: string }; flow: { intent: string } };

--- a/e2e/planning-orchestration.test.ts
+++ b/e2e/planning-orchestration.test.ts
@@ -354,6 +354,8 @@ describe('E2E: planning-orchestration', () => {
     let sessionId: string;
 
     it('orchestrate_plan should return plan with intent and flow info', async () => {
+      // 4 tasks → above the trivial-task fast-path threshold (#795), so the
+      // plan stays in draft for the explicit approve_plan call below.
       const res = await callOp(orchestrateFacade, 'orchestrate_plan', {
         prompt: 'Build a notification service that sends emails and push notifications',
         projectPath: workDir,
@@ -366,6 +368,14 @@ describe('E2E: planning-orchestration', () => {
           {
             title: 'Implement email sender',
             description: 'SMTP integration for email notifications',
+          },
+          {
+            title: 'Implement push sender',
+            description: 'APNs/FCM integration for mobile push notifications',
+          },
+          {
+            title: 'Add delivery retry queue',
+            description: 'Persist failed deliveries and retry with exponential backoff',
           },
         ],
       });

--- a/packages/core/src/runtime/facades/orchestrate-facade.test.ts
+++ b/packages/core/src/runtime/facades/orchestrate-facade.test.ts
@@ -21,10 +21,7 @@ vi.mock('../../utils/worktree-reaper.js', () => ({
 
 // ─── Helpers ────────────────────────────────────────────────────────
 
-function makeRuntime(
-  vault: Vault,
-  config: Partial<AgentRuntime['config']> = {},
-): AgentRuntime {
+function makeRuntime(vault: Vault, config: Partial<AgentRuntime['config']> = {}): AgentRuntime {
   const brain = new Brain(vault);
   const plansPath = join(tmpdir(), `orch-test-${Date.now()}.json`);
   const planner = new Planner(plansPath);

--- a/packages/core/src/runtime/orchestrate-ops.test.ts
+++ b/packages/core/src/runtime/orchestrate-ops.test.ts
@@ -367,7 +367,9 @@ describe('createOrchestrateOps', () => {
 
       await op.handler({
         prompt: longPrompt,
-        tasks: [{ title: 'Single task', description: 'Still too large because of objective size.' }],
+        tasks: [
+          { title: 'Single task', description: 'Still too large because of objective size.' },
+        ],
       });
 
       expect(rt.planner.create).toHaveBeenCalled();
@@ -395,7 +397,10 @@ describe('createOrchestrateOps', () => {
 
     it('does not fast-path when plan is deduplicated even if size-eligible', async () => {
       vi.mocked(rt.planner.create).mockReturnValue(
-        Object.assign({ id: 'plan-1', status: 'draft', objective: 'test', decisions: [], tasks: [] }, { _deduplicated: true }),
+        Object.assign(
+          { id: 'plan-1', status: 'draft', objective: 'test', decisions: [], tasks: [] },
+          { _deduplicated: true },
+        ),
       );
       const op = findOp(ops, 'orchestrate_plan');
 

--- a/packages/forge/src/agent-schema.ts
+++ b/packages/forge/src/agent-schema.ts
@@ -60,7 +60,13 @@ const CompactionPolicySchema = z.object({
     .optional(),
 });
 
-/** Session-start maintenance ops. All default off; opt in under engine.autoOps. */
+/**
+ * Session-start maintenance ops. All default off; opt in under engine.autoOps.
+ *
+ * Default value matches the full output type — Zod v4 rejects `.default({})`
+ * on object schemas whose inner fields have their own defaults
+ * (vault entry: typescript-1776088772668-p52eqp).
+ */
 const AutoOpsConfigSchema = z
   .object({
     dream: z.boolean().optional().default(false),
@@ -69,7 +75,7 @@ const AutoOpsConfigSchema = z
     staleClose: z.boolean().optional().default(false),
   })
   .optional()
-  .default({});
+  .default({ dream: false, selfHeal: false, orphanReaper: false, staleClose: false });
 
 /** Engine configuration */
 const EngineConfigSchema = z.object({
@@ -232,7 +238,10 @@ export const AgentYamlSchema = z.object({
 
   // ─── Engine ─────────────────────────────────────
   /** Knowledge engine configuration */
-  engine: EngineConfigSchema.optional().default({ learning: true }),
+  engine: EngineConfigSchema.optional().default({
+    learning: true,
+    autoOps: { dream: false, selfHeal: false, orphanReaper: false, staleClose: false },
+  }),
 
   // ─── Vault Connections ──────────────────────────
   /** Link to external vaults for shared knowledge */

--- a/packages/forge/src/skills/soleri-parallel-execute/SKILL.md
+++ b/packages/forge/src/skills/soleri-parallel-execute/SKILL.md
@@ -32,11 +32,11 @@ Pick a model per subagent at dispatch. Mixed tiers across a fan-out wave are exp
 
 ### Tier rubric
 
-| Tier | Model | Subagent purpose — trigger patterns |
-|------|-------|-------------------------------------|
-| simple | `haiku` | Exploration, file/symbol lookup, pattern search, single-fact retrieval, dedup detection, quick classification, data extraction from known formats |
-| standard | `sonnet` | Code implementation, refactors, test writing, documentation, migrations, data transformation, routine reviews, general research |
-| complex | `opus` | Architecture review, deep-review, plan creation, grading/scoring, critical bug diagnosis, cross-cutting design decisions, ambiguity resolution, nuanced writing |
+| Tier     | Model    | Subagent purpose — trigger patterns                                                                                                                             |
+| -------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| simple   | `haiku`  | Exploration, file/symbol lookup, pattern search, single-fact retrieval, dedup detection, quick classification, data extraction from known formats               |
+| standard | `sonnet` | Code implementation, refactors, test writing, documentation, migrations, data transformation, routine reviews, general research                                 |
+| complex  | `opus`   | Architecture review, deep-review, plan creation, grading/scoring, critical bug diagnosis, cross-cutting design decisions, ambiguity resolution, nuanced writing |
 
 ### Fallback chain
 
@@ -54,11 +54,11 @@ User pin always wins over rubric: "Run wave 2 on Opus" or "Use Haiku for task-5"
 
 A 3-way wave with mixed tiers:
 
-| Task | Purpose | Model | Tier |
-|------|---------|-------|------|
-| task-1 | Scan repo for unused exports | `haiku` | simple |
-| task-3 | Refactor parser into module | `sonnet` | standard |
-| task-5 | Review cross-module contract for safety | `opus` | complex |
+| Task   | Purpose                                 | Model    | Tier     |
+| ------ | --------------------------------------- | -------- | -------- |
+| task-1 | Scan repo for unused exports            | `haiku`  | simple   |
+| task-3 | Refactor parser into module             | `sonnet` | standard |
+| task-5 | Review cross-module contract for safety | `opus`   | complex  |
 
 All three dispatched in the **same Agent tool call batch**, each with its own `model` arg.
 

--- a/packages/forge/src/skills/soleri-subagent-driven-development/SKILL.md
+++ b/packages/forge/src/skills/soleri-subagent-driven-development/SKILL.md
@@ -39,15 +39,15 @@ Not all subagents are equal. Route by complexity:
 
 ## Model Selection
 
-Subagent-type (worker vs instance) picks *who* runs the task. Model selection picks *how much brain* they bring. Both decisions happen at dispatch, independently.
+Subagent-type (worker vs instance) picks _who_ runs the task. Model selection picks _how much brain_ they bring. Both decisions happen at dispatch, independently.
 
 ### Tier rubric
 
-| Tier | Model | Subagent purpose — trigger patterns |
-|------|-------|-------------------------------------|
-| simple | `haiku` | Exploration, file/symbol lookup, pattern search, single-fact retrieval, dedup detection, quick classification, data extraction from known formats |
-| standard | `sonnet` | Code implementation, refactors, test writing, documentation, migrations, data transformation, routine reviews, general research |
-| complex | `opus` | Architecture review, deep-review, plan creation, grading/scoring, critical bug diagnosis, cross-cutting design decisions, ambiguity resolution, nuanced writing |
+| Tier     | Model    | Subagent purpose — trigger patterns                                                                                                                             |
+| -------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| simple   | `haiku`  | Exploration, file/symbol lookup, pattern search, single-fact retrieval, dedup detection, quick classification, data extraction from known formats               |
+| standard | `sonnet` | Code implementation, refactors, test writing, documentation, migrations, data transformation, routine reviews, general research                                 |
+| complex  | `opus`   | Architecture review, deep-review, plan creation, grading/scoring, critical bug diagnosis, cross-cutting design decisions, ambiguity resolution, nuanced writing |
 
 ### Fallback chain
 


### PR DESCRIPTION
## Summary

Combines #812 + #813 + #814 into a single unblocker PR. Each was failing CI on its own because none of them had all 3 fixes simultaneously. This stack is the minimum delta needed to turn `main`'s required checks green.

**Why one PR instead of three:** required checks (`Build`, `Code Quality`, `E2E Tests`) were each failing for different reasons. CI on a per-PR branch only sees that PR's diff, so #812 alone passed Build but failed Code Quality + E2E; #813 alone fixed Code Quality but failed Build; #814 alone fixed E2E but failed Build. Stacking them was the path of least churn.

## What's in here

| Fix | Files | Why |
|---|---|---|
| Zod v4 typed defaults | `packages/forge/src/agent-schema.ts` | `tsc` (emit mode) rejected `.default({})` on object schemas with inner-field defaults — chronic build break |
| `oxfmt` formatting | 4 files (2 test files, 2 SKILL.md) | Pre-existing format drift on main flagged by `Code Quality` |
| E2E fast-path bypass | 4 e2e test files (4 `orchestrate_plan` calls extended to 4 tasks) | `972664d` (Epic #794 task 1) added auto-approve+execute for trivial plans; existing E2E tests expected old draft-then-approve flow |

The E2E fix is the load-bearing one — chronic CI red on main since 2026-05-01 traces directly to commit `972664d` (the fast-path gate) not updating tests that asserted the old behavior.

## Test plan

- [x] `npm --workspace=@soleri/forge run build` — clean
- [x] `npm --workspace=@soleri/forge test -- --run` — 173 / 173
- [x] `npm run test:e2e` — **917 / 917** (light: 825/825, heavy: 92/92)

## Once this lands

PRs #808, #809, #810, #811 (Epic #794 wave-2/3 work) all have auto-merge queued. They'll cascade through once required checks pass. Closes #812, #813, #814 (superseded by this stack).
