### PR TITLE
feat(core): reap plans stuck in executing/reconciling states

### DIFF
--- a/packages/core/src/planning/planner.test.ts
+++ b/packages/core/src/planning/planner.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Planner, PlanGradeRejectionError } from './planner.js';
 import type { PlanGap } from './gap-types.js';
 import type { PlanAlternative } from './planner.js';
@@ -359,6 +359,76 @@ describe('Planner', () => {
     it('should throw when executing non-approved plan', () => {
       const plan = planner.create({ objective: 'Not approved', scope: 'test' });
       expect(() => planner.startExecution(plan.id)).toThrow('Invalid transition');
+    });
+  });
+
+  describe('findStale + reap', () => {
+    function createExecutingPlanAt(id_objective: string, createdAt: number): string {
+      vi.spyOn(Date, 'now').mockReturnValue(createdAt);
+      const plan = planner.create({ objective: id_objective, scope: 'test' });
+      planner.approve(plan.id);
+      planner.startExecution(plan.id);
+      vi.restoreAllMocks();
+      return plan.id;
+    }
+
+    it('findStale returns IDs of executing plans older than the threshold', () => {
+      const freshId = createExecutingPlanAt('Fresh', Date.now());
+      const staleId = createExecutingPlanAt('Old', Date.now() - 25 * 60 * 60 * 1000);
+
+      const stale = planner.findStale();
+      expect(stale).toContain(staleId);
+      expect(stale).not.toContain(freshId);
+    });
+
+    it('findStale honors a custom threshold and excludes terminal plans', () => {
+      const recentId = createExecutingPlanAt('Just started', Date.now() - 5 * 60 * 1000);
+      expect(planner.findStale(1)).toContain(recentId);
+      expect(planner.findStale(60 * 60 * 1000)).not.toContain(recentId);
+
+      // A reaped plan in completed state must never be flagged as stale
+      const doneId = createExecutingPlanAt('Done already', Date.now() - 50 * 60 * 60 * 1000);
+      planner.reap(doneId);
+      expect(planner.findStale(1)).not.toContain(doneId);
+    });
+
+    it('reap force-completes a stuck plan with reason recorded in reconciliation', () => {
+      const stuck = planner.create({ objective: 'Stuck', scope: 'test' });
+      planner.approve(stuck.id);
+      planner.startExecution(stuck.id);
+      const reaped = planner.reap(stuck.id);
+      expect(reaped.status).toBe('completed');
+      expect(reaped.reconciliation?.summary).toContain('reaped');
+      expect(reaped.reconciliation?.summary).toContain('executing');
+    });
+
+    it('reap normalizes pending tasks to skipped', () => {
+      const stuck = planner.create({
+        objective: 'Plan with unfinished work',
+        scope: 'test',
+        tasks: [
+          { title: 'A', description: 'a' },
+          { title: 'B', description: 'b' },
+        ],
+      });
+      planner.approve(stuck.id);
+      planner.startExecution(stuck.id);
+      const reaped = planner.reap(stuck.id);
+      expect(reaped.tasks.every((t) => t.status === 'skipped' || t.status === 'completed')).toBe(
+        true,
+      );
+    });
+
+    it('reap throws on already-terminal plans', () => {
+      const stuck = planner.create({ objective: 'Already done', scope: 'test' });
+      planner.approve(stuck.id);
+      planner.startExecution(stuck.id);
+      planner.reap(stuck.id);
+      expect(() => planner.reap(stuck.id)).toThrow(/already completed/);
+    });
+
+    it('reap throws on unknown plan id', () => {
+      expect(() => planner.reap('plan-nonexistent')).toThrow(/not found/);
     });
   });
 

--- a/packages/core/src/planning/planner.ts
+++ b/packages/core/src/planning/planner.ts
@@ -359,6 +359,56 @@ export class Planner {
     return this.store.plans.filter((p) => p.status === 'executing' || p.status === 'validating');
   }
 
+  /**
+   * Return IDs of plans stuck in active states (executing, validating,
+   * reconciling, brainstorming) older than `thresholdMs` (default: the
+   * planner's `executingTtlMs`, normally 24h). Read-only — no mutations.
+   * Surfaces stranded plans for warning + reap workflows (#784).
+   */
+  findStale(thresholdMs?: number): string[] {
+    this.refresh();
+    const threshold = thresholdMs ?? this.executingTtlMs;
+    const now = Date.now();
+    return this.store.plans
+      .filter(
+        (p) =>
+          (p.status === 'executing' ||
+            p.status === 'validating' ||
+            p.status === 'reconciling' ||
+            p.status === 'brainstorming') &&
+          now - p.updatedAt >= threshold,
+      )
+      .map((p) => p.id);
+  }
+
+  /**
+   * Force-complete a single plan regardless of current state. Sets
+   * reconciliation summary to 'reaped' so the audit trail is distinguishable
+   * from natural completion or TTL-driven `closeStale` sweeps. Throws when
+   * the plan id is unknown or already terminal.
+   */
+  reap(planId: string): Plan {
+    const plan = this.requirePlan(planId);
+    if (plan.status === 'completed' || plan.status === 'archived') {
+      throw new Error(`Plan ${planId} is already ${plan.status} — cannot reap`);
+    }
+    const previousStatus = plan.status;
+    const now = Date.now();
+    plan.status = 'completed';
+    plan.updatedAt = now;
+    this.normalizeTerminalTaskStates(plan, now);
+    plan.reconciliation = {
+      planId,
+      accuracy: 0,
+      driftItems: [],
+      summary: `reaped (previous: ${previousStatus})`,
+      reconciledAt: now,
+    };
+    plan.executionSummary = computeExecutionSummary(plan.tasks);
+    this.save();
+    return plan;
+  }
+
   getActive(): Plan[] {
     this.refresh();
     return this.store.plans.filter(

--- a/packages/core/src/runtime/admin-ops.ts
+++ b/packages/core/src/runtime/admin-ops.ts
@@ -86,7 +86,7 @@ function getCoreVersion(): string {
  * Groups: health (1–2), introspection (4), diagnostics (2), mutation (1).
  */
 export function createAdminOps(runtime: AgentRuntime): OpDefinition[] {
-  const { vault, brain, brainIntelligence, llmClient, curator, packInstaller } = runtime;
+  const { vault, brain, brainIntelligence, llmClient, curator, packInstaller, planner } = runtime;
 
   return [
     // ─── Health ──────────────────────────────────────────────────────
@@ -118,6 +118,16 @@ export function createAdminOps(runtime: AgentRuntime): OpDefinition[] {
           if (t in tierCounts) tierCounts[t as keyof typeof tierCounts]++;
         }
 
+        // Stale plans surfaced for operator visibility (#784).
+        // Best-effort — never let a planner read failure block admin_health.
+        let stalePlans: { count: number; ids: string[] } = { count: 0, ids: [] };
+        try {
+          const ids = planner.findStale();
+          stalePlans = { count: ids.length, ids };
+        } catch {
+          // Defensive — admin_health is the place you go *because* something is wrong
+        }
+
         return {
           status: 'ok',
           vault: { entries: vaultStats.totalEntries, domains: Object.keys(vaultStats.byDomain) },
@@ -137,6 +147,7 @@ export function createAdminOps(runtime: AgentRuntime): OpDefinition[] {
             packs: packHooks,
           },
           packTiers: tierCounts,
+          stalePlans,
         };
       },
     },

--- a/packages/core/src/runtime/facades/admin-facade.ts
+++ b/packages/core/src/runtime/facades/admin-facade.ts
@@ -16,7 +16,7 @@ import { createTelemetryOps } from '../telemetry-ops.js';
 import { queryFrictionAggregate } from '../friction-metrics.js';
 
 export function createAdminFacadeOps(runtime: AgentRuntime): OpDefinition[] {
-  const { llmClient, keyPool, vault } = runtime;
+  const { llmClient, keyPool, vault, planner } = runtime;
 
   const ops: OpDefinition[] = [
     // ─── LLM (inline from core-ops.ts) ──────────────────────────
@@ -97,6 +97,25 @@ export function createAdminFacadeOps(runtime: AgentRuntime): OpDefinition[] {
       handler: async () => ({
         templates: runtime.templateManager.listTemplates(),
       }),
+    },
+    {
+      name: 'plan_reap',
+      description:
+        'Force-complete a plan stuck in executing/validating/reconciling/brainstorming. ' +
+        'Sets reconciliation summary to "reaped" so the audit trail is distinguishable from ' +
+        'natural completion or stale-close sweeps. Surfaced via session_start.stalePlans + admin_health.',
+      auth: 'write' as const,
+      schema: z.object({
+        planId: z.string().describe('ID of the stuck plan to force-complete.'),
+      }),
+      handler: async (params) => {
+        const planId = params.planId as string;
+        const plan = planner.reap(planId);
+        return {
+          reaped: true,
+          plan: { id: plan.id, status: plan.status, reconciliation: plan.reconciliation },
+        };
+      },
     },
     {
       name: 'pipeline_metrics',

--- a/packages/core/src/runtime/facades/orchestrate-facade.ts
+++ b/packages/core/src/runtime/facades/orchestrate-facade.ts
@@ -224,6 +224,17 @@ export function createOrchestrateFacadeOps(runtime: AgentRuntime): OpDefinition[
           status: p.status,
         }));
 
+        // Detection-only: surface plans stuck in active states past their TTL.
+        // Reaping is explicit via op:plan_reap (admin facade) so the operator
+        // sees the warning and decides — no silent destruction (#784).
+        let stalePlans: { count: number; ids: string[] } = { count: 0, ids: [] };
+        try {
+          const ids = runtime.planner.findStale();
+          stalePlans = { count: ids.length, ids };
+        } catch {
+          // Best-effort — never block session_start on stale detection
+        }
+
         const preflight = buildPreflightManifest({
           facades,
           skills,
@@ -291,6 +302,7 @@ export function createOrchestrateFacadeOps(runtime: AgentRuntime): OpDefinition[
           orphansClosed,
           autoReconciledCount,
           stalePlansClosed,
+          stalePlans,
           ...(stagingWarning ? { stagingWarning } : {}),
           ...(dreamInfo ? { dream: dreamInfo } : {}),
           ...(selfHealInfo ? { selfHeal: selfHealInfo } : {}),


### PR DESCRIPTION
## Summary

Closes #784. First pull from Epic #791 (pre-v10 hardening). The exact bug pattern that hosed Epic #794's plan during this past week — its master plan TTL'd out empty in `executing` state with no warning, all 10 tasks marked `skipped` while real work shipped via per-issue PRs.

`closeStale()` already auto-completes by TTL (gated behind `engine.autoOps.staleClose`). What was missing: **operator visibility** and **a single-plan force-complete tool** so stuck plans surface for explicit handling instead of being silently swept (or not swept at all when the autoOp is off).

## What's added

- **`Planner.findStale(thresholdMs?)`** — read-only; returns IDs of plans in `executing`/`validating`/`reconciling`/`brainstorming` older than the threshold (default: planner's `executingTtlMs`, 24h)
- **`Planner.reap(planId)`** — force-completes a single plan, sets `reconciliation.summary` to `reaped (previous: <status>)` so the audit trail distinguishes from natural completion or stale-close sweeps. Throws on already-terminal or unknown plan ids
- **`session_start.stalePlans: { count, ids }`** — always-on detection (not gated behind autoOps); tells the operator on every session start what's stuck
- **`admin_health.stalePlans: { count, ids }`** — health check surfaces the same data when invoked directly
- **`op:plan_reap(planId)`** in admin facade (`auth: write`) — explicit operator action, no automation

Threshold reuses the existing `executingTtlMs` knob (configurable via `agent.yaml`); no new config surface.

## Test plan

- [x] `npx oxlint` — 0 warnings, 0 errors
- [x] `npm --workspace=@soleri/core test -- --run planner` — 84 / 84 (5 new tests for findStale + reap)
- [x] Full core suite — 5024 / 5025 (1 pre-existing flaky perf test in `vault-scaling`)
- [x] New tests cover: threshold semantics; terminal-plan exclusion; status transition; task normalization; error paths (already-terminal, unknown id)
