### PR TITLE
feat(ci): add doc-drift checker to detect docs vs source divergence

### DIFF
--- a/.github/workflows/doc-drift.yml
+++ b/.github/workflows/doc-drift.yml
@@ -1,0 +1,24 @@
+name: Doc Drift
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  doc-drift:
+    name: Doc Drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'npm'
+      - run: npm ci
+      - name: Detector unit tests
+        run: npm run docs:check-drift:test
+      - name: Run drift check
+        run: npm run docs:check-drift

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "deadcode:ts-prune": "ts-prune",
     "test:e2e": "vitest run --config e2e/vitest.config.ts --dir e2e && vitest run --config e2e/vitest.heavy.config.ts",
     "validate-skills": "tsx packages/core/src/skills/validate-skill-docs.ts",
+    "docs:check-drift": "tsx scripts/check-docs-drift.ts",
+    "docs:check-drift:test": "vitest run --root . scripts/check-docs-drift.test.ts",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/check-docs-drift.test.ts
+++ b/scripts/check-docs-drift.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for the doc-drift checker (#779). Each detector is exercised with
+ * synthetic source + doc fixtures so a real source change cannot mask a
+ * regression in the matcher itself.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  extractStringArrayConst,
+  findValuesLines,
+  checkEnumDrift,
+  listCliCommands,
+  findDocCommandSections,
+  checkCliCommandDrift,
+  extractFullProfileModules,
+  findModuleCountClaims,
+  checkModuleCountDrift,
+  extractProfileModule,
+  findProfileTableRows,
+  checkProfileModuleDrift,
+  runAllDetectors,
+} from './check-docs-drift.js';
+import { readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('extractStringArrayConst', () => {
+  it('extracts a flat string-array as-const declaration', () => {
+    const src = `export const TONES = ['precise', 'mentor', 'pragmatic'] as const;`;
+    expect(extractStringArrayConst(src, 'TONES')).toEqual(['precise', 'mentor', 'pragmatic']);
+  });
+
+  it('extracts a multi-line declaration', () => {
+    const src = `export const ENGINE_PROFILES = [
+  'minimal',
+  'standard',
+  'full',
+] as const;`;
+    expect(extractStringArrayConst(src, 'ENGINE_PROFILES')).toEqual([
+      'minimal',
+      'standard',
+      'full',
+    ]);
+  });
+
+  it('returns null for unknown identifier', () => {
+    const src = `export const TONES = ['a'] as const;`;
+    expect(extractStringArrayConst(src, 'MISSING')).toBeNull();
+  });
+});
+
+describe('findValuesLines', () => {
+  it('extracts backtick-quoted enum values from "**Values:**" lines', () => {
+    const doc = `
+intro
+- **Values:** \`precise\` | \`mentor\` | \`pragmatic\`
+- **Default:** \`pragmatic\`
+`;
+    const out = findValuesLines(doc);
+    expect(out).toHaveLength(1);
+    expect(out[0].values).toEqual(['precise', 'mentor', 'pragmatic']);
+  });
+
+  it('returns empty when no values line is present', () => {
+    expect(findValuesLines('plain text only')).toEqual([]);
+  });
+});
+
+describe('checkEnumDrift', () => {
+  const schema = `
+export const TONES = ['precise', 'mentor', 'pragmatic'] as const;
+export const ENGINE_PROFILES = ['minimal', 'standard', 'full'] as const;
+export const SETUP_TARGETS = ['claude', 'codex', 'opencode', 'both', 'all'] as const;
+`;
+
+  it('reports drift when doc adds an enum value not in source', () => {
+    const doc = `### tone
+- **Values:** \`precise\` | \`mentor\` | \`pragmatic\` | \`extra\`
+`;
+    const drifts = checkEnumDrift(schema, 'docs/x.md', doc);
+    expect(drifts).toHaveLength(1);
+    expect(drifts[0].detector).toBe('enum:TONES');
+    expect(drifts[0].expected).toBe('mentor | pragmatic | precise');
+    expect(drifts[0].actual).toBe('extra | mentor | pragmatic | precise');
+  });
+
+  it('reports drift when doc drops an enum value present in source', () => {
+    const doc = `### tone
+- **Values:** \`precise\` | \`mentor\`
+`;
+    const drifts = checkEnumDrift(schema, 'docs/x.md', doc);
+    expect(drifts).toHaveLength(1);
+    expect(drifts[0].detector).toBe('enum:TONES');
+  });
+
+  it('passes when doc matches source exactly', () => {
+    const doc = `- **Values:** \`precise\` | \`mentor\` | \`pragmatic\``;
+    expect(checkEnumDrift(schema, 'docs/x.md', doc)).toEqual([]);
+  });
+
+  it('ignores unrelated values lines (no overlap with any tracked enum)', () => {
+    const doc = `- **Values:** \`red\` | \`green\` | \`blue\``;
+    expect(checkEnumDrift(schema, 'docs/x.md', doc)).toEqual([]);
+  });
+});
+
+describe('listCliCommands', () => {
+  it('returns ts files without the .ts suffix and excludes test files', () => {
+    const dir = join(REPO_ROOT, 'packages/cli/src/commands');
+    const cmds = listCliCommands(dir);
+    expect(cmds.length).toBeGreaterThan(5);
+    expect(cmds.every((c) => !c.endsWith('.test'))).toBe(true);
+    // Cross-check against on-disk listing (sanity)
+    const raw = readdirSync(dir).filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'));
+    expect(cmds.length).toBe(raw.length);
+  });
+});
+
+describe('findDocCommandSections', () => {
+  it('only collects ### sections under ## Commands, stops at next H2', () => {
+    const doc = `# Title
+## Install
+### irrelevant
+## Commands
+### create
+### list
+### dev
+## Other
+### shouldnotcount
+`;
+    const out = findDocCommandSections(doc);
+    expect([...out.commands].sort()).toEqual(['create', 'dev', 'list']);
+    expect(out.firstLine).toBeGreaterThan(0);
+  });
+});
+
+describe('checkCliCommandDrift', () => {
+  it('reports when a source command is missing from docs', () => {
+    const doc = `## Commands
+### create
+### list
+`;
+    const drifts = checkCliCommandDrift(['create', 'list', 'dev'], 'docs/cli.md', doc);
+    expect(drifts).toHaveLength(1);
+    expect(drifts[0].detector).toBe('cli:commands');
+    expect(drifts[0].expected).toContain('dev');
+    expect(drifts[0].actual).not.toContain('dev');
+  });
+
+  it('reports when docs claim a command not in source', () => {
+    const doc = `## Commands
+### create
+### list
+### ghost
+`;
+    const drifts = checkCliCommandDrift(['create', 'list'], 'docs/cli.md', doc);
+    expect(drifts).toHaveLength(1);
+    expect(drifts[0].actual).toContain('ghost');
+  });
+
+  it('passes when sets match exactly', () => {
+    const doc = `## Commands
+### create
+### list
+`;
+    expect(checkCliCommandDrift(['create', 'list'], 'docs/cli.md', doc)).toEqual([]);
+  });
+});
+
+describe('extractFullProfileModules', () => {
+  it('parses the full profile array from registry source', () => {
+    const src = `export const PROFILE_MODULES = {
+  minimal: ['vault', 'admin'],
+  full: ['vault', 'plan', 'brain', 'memory', 'admin'],
+} as const;`;
+    expect(extractFullProfileModules(src)).toEqual(['vault', 'plan', 'brain', 'memory', 'admin']);
+  });
+});
+
+describe('findModuleCountClaims', () => {
+  it('captures every "All N modules" line', () => {
+    const doc = `text
+| \`full\` | All 22 modules | description |
+note: All 5 modules used elsewhere
+`;
+    expect(findModuleCountClaims(doc)).toEqual([
+      { line: 2, count: 22 },
+      { line: 3, count: 5 },
+    ]);
+  });
+});
+
+describe('checkModuleCountDrift', () => {
+  it('flags when claimed count diverges from source length', () => {
+    const drifts = checkModuleCountDrift(
+      ['vault', 'admin', 'plan'],
+      'docs/x.md',
+      `| \`full\` | All 22 modules | … |`,
+    );
+    expect(drifts).toHaveLength(1);
+    expect(drifts[0].expected).toBe('All 3 modules');
+    expect(drifts[0].actual).toBe('All 22 modules');
+  });
+
+  it('passes when count matches', () => {
+    expect(
+      checkModuleCountDrift(
+        ['vault', 'admin', 'plan'],
+        'docs/x.md',
+        `| \`full\` | All 3 modules | … |`,
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe('extractProfileModule + findProfileTableRows', () => {
+  it('extracts each named profile array', () => {
+    const src = `export const PROFILE_MODULES = {
+  minimal: ['vault', 'admin', 'control', 'orchestrate'],
+  standard: ['vault', 'plan', 'admin'],
+  full: ['vault', 'plan', 'brain'],
+} as const;`;
+    expect(extractProfileModule(src, 'minimal')).toEqual([
+      'vault',
+      'admin',
+      'control',
+      'orchestrate',
+    ]);
+    expect(extractProfileModule(src, 'standard')).toEqual(['vault', 'plan', 'admin']);
+  });
+
+  it('finds profile rows in a markdown table', () => {
+    const doc = `| Profile | Modules | Best for |
+| ------- | ------- | -------- |
+| \`minimal\` | vault, admin, control, orchestrate | bots |
+| \`standard\` | + plan, brain, memory | dev agents |
+| \`full\` | All 22 modules | default |
+`;
+    const rows = findProfileTableRows(doc);
+    const minimal = rows.find((r) => r.profile === 'minimal');
+    const standard = rows.find((r) => r.profile === 'standard');
+    expect(minimal?.modules).toEqual(['vault', 'admin', 'control', 'orchestrate']);
+    expect(standard?.modules).toEqual(['plan', 'brain', 'memory']);
+  });
+});
+
+describe('checkProfileModuleDrift', () => {
+  const registry = `export const PROFILE_MODULES = {
+  minimal: ['vault', 'admin', 'control', 'orchestrate'],
+  standard: ['vault', 'admin', 'control', 'orchestrate', 'plan', 'brain', 'memory'],
+  full: ['vault', 'admin', 'control', 'orchestrate', 'plan', 'brain', 'memory', 'dream'],
+} as const;`;
+
+  it('flags when minimal cell diverges from source', () => {
+    const doc = `| \`minimal\` | vault, admin, control | bots |`;
+    const drifts = checkProfileModuleDrift(registry, 'docs/x.md', doc);
+    expect(drifts).toHaveLength(1);
+    expect(drifts[0].detector).toBe('engine:profile:minimal');
+  });
+
+  it('treats "+ delta" notation in standard as additive over minimal', () => {
+    const doc = `| \`minimal\` | vault, admin, control, orchestrate | bots |
+| \`standard\` | + plan, brain, memory | dev |`;
+    const drifts = checkProfileModuleDrift(registry, 'docs/x.md', doc);
+    expect(drifts).toEqual([]);
+  });
+
+  it('flags when standard delta drops a real addition', () => {
+    const doc = `| \`standard\` | + plan, brain | dev |`;
+    const drifts = checkProfileModuleDrift(registry, 'docs/x.md', doc);
+    const standardDrift = drifts.find((d) => d.detector === 'engine:profile:standard');
+    expect(standardDrift).toBeDefined();
+    expect(standardDrift!.expected).toContain('memory');
+  });
+});
+
+describe('runAllDetectors against live docs (regression)', () => {
+  it('current main is drift-free — adding a doc claim or shipping code without doc update should fail this', () => {
+    const drifts = runAllDetectors();
+    if (drifts.length > 0) {
+      // Print the report so a failing CI run is readable
+      console.error(JSON.stringify(drifts, null, 2));
+    }
+    expect(drifts).toEqual([]);
+  });
+});

--- a/scripts/check-docs-drift.ts
+++ b/scripts/check-docs-drift.ts
@@ -1,0 +1,329 @@
+#!/usr/bin/env tsx
+/**
+ * Doc-drift checker — fails CI when claims in `src/content/docs/` diverge
+ * from source-of-truth in `packages/`.
+ *
+ * Detectors (Epic #791 / issue #779):
+ *   1. Enum lists (TONES, ENGINE_PROFILES, SETUP_TARGETS) — extracted from
+ *      packages/forge/src/agent-schema.ts vs. claims in agent-yaml-reference.md
+ *   2. CLI command list — packages/cli/src/commands/*.ts vs. ### sections in
+ *      cli-reference.md (under ## Commands)
+ *   3. Engine module count — PROFILE_MODULES.full length in
+ *      packages/core/src/engine/module-registry.ts vs. "All N modules" claims
+ *   4. Engine profile module sets — PROFILE_MODULES.{minimal,standard,full}
+ *      vs. the profile table in agent-yaml-reference.md
+ *
+ * Run: `npm run docs:check-drift`
+ * CI:  `.github/workflows/doc-drift.yml`
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const DOCS_ROOT = join(REPO_ROOT, 'src/content/docs/docs');
+const AGENT_SCHEMA = join(REPO_ROOT, 'packages/forge/src/agent-schema.ts');
+const MODULE_REGISTRY = join(REPO_ROOT, 'packages/core/src/engine/module-registry.ts');
+const CLI_COMMANDS_DIR = join(REPO_ROOT, 'packages/cli/src/commands');
+
+export interface Drift {
+  detector: string;
+  file: string;
+  line: number;
+  expected: string;
+  actual: string;
+}
+
+// ─── Detector 1: Enum drift ──────────────────────────────────────────
+
+/** Extract a string-array constant declaration from a TypeScript source file. */
+export function extractStringArrayConst(source: string, name: string): string[] | null {
+  const re = new RegExp(`export\\s+const\\s+${name}\\s*=\\s*\\[([^\\]]*)\\]\\s*as\\s*const`, 's');
+  const m = source.match(re);
+  if (!m) return null;
+  return [...m[1].matchAll(/'([^']+)'/g)].map((mm) => mm[1]);
+}
+
+/** Doc convention: `**Values:** \`a\` | \`b\` | \`c\`` lines list enum values. */
+export function findValuesLines(doc: string): Array<{ line: number; values: string[] }> {
+  const out: Array<{ line: number; values: string[] }> = [];
+  const lines = doc.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/\*\*Values:\*\*\s+(.+)/);
+    if (!m) continue;
+    const values = [...m[1].matchAll(/`([^`]+)`/g)].map((mm) => mm[1]);
+    if (values.length > 0) out.push({ line: i + 1, values });
+  }
+  return out;
+}
+
+export function checkEnumDrift(schemaSource: string, docPath: string, docContent: string): Drift[] {
+  const drifts: Drift[] = [];
+  const enumsToCheck: Array<{ name: string; field: string }> = [
+    { name: 'TONES', field: 'tone' },
+    { name: 'ENGINE_PROFILES', field: 'engine.profile' },
+    { name: 'SETUP_TARGETS', field: 'setup.target' },
+  ];
+
+  for (const { name } of enumsToCheck) {
+    const sourceValues = extractStringArrayConst(schemaSource, name);
+    if (!sourceValues) continue;
+    const sourceSet = new Set(sourceValues);
+    for (const { line, values } of findValuesLines(docContent)) {
+      const docSet = new Set(values);
+      // Only treat as a candidate match if every doc value is in source OR vice versa
+      // (avoids matching unrelated `**Values:**` lines for other enums)
+      const overlap = [...docSet].filter((v) => sourceSet.has(v));
+      if (overlap.length === 0) continue;
+      // Now require an exact set match
+      if (sourceSet.size !== docSet.size || overlap.length !== sourceSet.size) {
+        drifts.push({
+          detector: `enum:${name}`,
+          file: docPath,
+          line,
+          expected: [...sourceSet].sort().join(' | '),
+          actual: [...docSet].sort().join(' | '),
+        });
+      }
+    }
+  }
+  return drifts;
+}
+
+// ─── Detector 2: CLI command list drift ──────────────────────────────
+
+export function listCliCommands(commandsDir: string): string[] {
+  return readdirSync(commandsDir)
+    .filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'))
+    .map((f) => f.replace(/\.ts$/, ''))
+    .sort();
+}
+
+export function findDocCommandSections(doc: string): {
+  commands: Set<string>;
+  firstLine: number;
+} {
+  const lines = doc.split('\n');
+  let inCommands = false;
+  let firstLine = 0;
+  const commands = new Set<string>();
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^##\s+Commands\s*$/.test(line)) {
+      inCommands = true;
+      continue;
+    }
+    if (inCommands && /^##\s+(?!#)/.test(line)) {
+      // Hit the next H2 — Commands section is closed
+      break;
+    }
+    if (inCommands) {
+      const m = line.match(/^###\s+([\w-]+)\s*$/);
+      if (m) {
+        if (firstLine === 0) firstLine = i + 1;
+        commands.add(m[1]);
+      }
+    }
+  }
+  return { commands, firstLine };
+}
+
+export function checkCliCommandDrift(
+  sourceCommands: string[],
+  docPath: string,
+  docContent: string,
+): Drift[] {
+  const sourceSet = new Set(sourceCommands);
+  const { commands: docCommands, firstLine } = findDocCommandSections(docContent);
+  const missingFromDocs = [...sourceSet].filter((c) => !docCommands.has(c));
+  const extraInDocs = [...docCommands].filter((c) => !sourceSet.has(c));
+  if (missingFromDocs.length === 0 && extraInDocs.length === 0) return [];
+  return [
+    {
+      detector: 'cli:commands',
+      file: docPath,
+      line: firstLine,
+      expected: [...sourceSet].sort().join(', '),
+      actual: [...docCommands].sort().join(', '),
+    },
+  ];
+}
+
+// ─── Detector 3: Engine module count ─────────────────────────────────
+
+export function extractFullProfileModules(registrySource: string): string[] | null {
+  const m = registrySource.match(/full:\s*\[([^\]]*)\]/s);
+  if (!m) return null;
+  return [...m[1].matchAll(/'([^']+)'/g)].map((mm) => mm[1]);
+}
+
+/** Doc convention: `All N modules` (e.g. "All 22 modules"). */
+export function findModuleCountClaims(doc: string): Array<{ line: number; count: number }> {
+  const out: Array<{ line: number; count: number }> = [];
+  const lines = doc.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/All\s+(\d+)\s+modules\b/i);
+    if (m) out.push({ line: i + 1, count: parseInt(m[1], 10) });
+  }
+  return out;
+}
+
+export function checkModuleCountDrift(
+  fullModules: string[],
+  docPath: string,
+  docContent: string,
+): Drift[] {
+  const expected = fullModules.length;
+  return findModuleCountClaims(docContent)
+    .filter((c) => c.count !== expected)
+    .map((c) => ({
+      detector: 'engine:moduleCount',
+      file: docPath,
+      line: c.line,
+      expected: `All ${expected} modules`,
+      actual: `All ${c.count} modules`,
+    }));
+}
+
+// ─── Detector 4: Profile module sets ─────────────────────────────────
+
+export function extractProfileModule(
+  registrySource: string,
+  profile: 'minimal' | 'standard' | 'full',
+): string[] | null {
+  const re = new RegExp(`${profile}:\\s*\\[([^\\]]*)\\]`, 's');
+  const m = registrySource.match(re);
+  if (!m) return null;
+  return [...m[1].matchAll(/'([^']+)'/g)].map((mm) => mm[1]);
+}
+
+/**
+ * Doc convention: a markdown table row like
+ * `| `minimal` | vault, admin, control, orchestrate | ...`
+ * We detect rows whose first cell wraps a known profile name in backticks.
+ */
+export function findProfileTableRows(
+  doc: string,
+): Array<{ line: number; profile: string; modules: string[] }> {
+  const out: Array<{ line: number; profile: string; modules: string[] }> = [];
+  const lines = doc.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^\|\s*`(minimal|standard|full)`\s*\|\s*([^|]+?)\s*\|/);
+    if (!m) continue;
+    const profile = m[1];
+    const cell = m[2].trim();
+    // Cells may include "+ vault, plan, ..." — strip a leading + and split commas
+    const modules = cell
+      .replace(/^\+\s*/, '')
+      .split(',')
+      .map((s) => s.trim().replace(/[\s,]+$/, ''))
+      .filter((s) => s.length > 0 && /^[\w-]+$/.test(s));
+    if (modules.length > 0) out.push({ line: i + 1, profile, modules });
+  }
+  return out;
+}
+
+export function checkProfileModuleDrift(
+  registrySource: string,
+  docPath: string,
+  docContent: string,
+): Drift[] {
+  const drifts: Drift[] = [];
+  for (const row of findProfileTableRows(docContent)) {
+    if (row.profile === 'full') {
+      // The "full" cell often says "All N modules", not the literal list — handled by detector 3
+      continue;
+    }
+    const sourceModules = extractProfileModule(
+      registrySource,
+      row.profile as 'minimal' | 'standard',
+    );
+    if (!sourceModules) continue;
+    const sourceSet = new Set(sourceModules);
+    const docSet = new Set(row.modules);
+
+    // Standard profile in docs uses additive notation ("+ plan, brain, ...")
+    // meaning "minimal modules + these". Re-derive expected delta if we can.
+    let expectedSet = sourceSet;
+    if (row.profile === 'standard') {
+      const minimal = extractProfileModule(registrySource, 'minimal');
+      if (minimal) {
+        expectedSet = new Set(sourceModules.filter((m) => !minimal.includes(m)));
+      }
+    }
+
+    if (
+      expectedSet.size !== docSet.size ||
+      [...expectedSet].some((m) => !docSet.has(m)) ||
+      [...docSet].some((m) => !expectedSet.has(m))
+    ) {
+      drifts.push({
+        detector: `engine:profile:${row.profile}`,
+        file: docPath,
+        line: row.line,
+        expected: [...expectedSet].sort().join(', '),
+        actual: [...docSet].sort().join(', '),
+      });
+    }
+  }
+  return drifts;
+}
+
+// ─── Runner ──────────────────────────────────────────────────────────
+
+function loadDoc(name: string): { path: string; content: string } | null {
+  const path = join(DOCS_ROOT, name);
+  if (!existsSync(path)) return null;
+  return { path, content: readFileSync(path, 'utf-8') };
+}
+
+function relPath(absPath: string): string {
+  return absPath.startsWith(REPO_ROOT) ? absPath.slice(REPO_ROOT.length + 1) : absPath;
+}
+
+export function runAllDetectors(): Drift[] {
+  const drifts: Drift[] = [];
+  const schemaSource = readFileSync(AGENT_SCHEMA, 'utf-8');
+  const registrySource = readFileSync(MODULE_REGISTRY, 'utf-8');
+  const cliCommands = listCliCommands(CLI_COMMANDS_DIR);
+
+  const agentYaml = loadDoc('agent-yaml-reference.md');
+  if (agentYaml) {
+    drifts.push(...checkEnumDrift(schemaSource, relPath(agentYaml.path), agentYaml.content));
+    const fullModules = extractFullProfileModules(registrySource) ?? [];
+    drifts.push(...checkModuleCountDrift(fullModules, relPath(agentYaml.path), agentYaml.content));
+    drifts.push(
+      ...checkProfileModuleDrift(registrySource, relPath(agentYaml.path), agentYaml.content),
+    );
+  }
+
+  const cliRef = loadDoc('cli-reference.md');
+  if (cliRef) {
+    drifts.push(...checkCliCommandDrift(cliCommands, relPath(cliRef.path), cliRef.content));
+  }
+
+  return drifts;
+}
+
+function main(): void {
+  const drifts = runAllDetectors();
+  if (drifts.length === 0) {
+    console.log('doc-drift: no drift detected');
+    process.exit(0);
+  }
+  console.error(`doc-drift: ${drifts.length} drift(s) detected:\n`);
+  for (const d of drifts) {
+    console.error(`  [${d.detector}] ${d.file}:${d.line}`);
+    console.error(`    expected: ${d.expected}`);
+    console.error(`    actual:   ${d.actual}\n`);
+  }
+  process.exit(1);
+}
+
+const isDirectExecution =
+  process.argv[1]?.endsWith('check-docs-drift.ts') ||
+  process.argv[1]?.endsWith('check-docs-drift.js');
+if (isDirectExecution) {
+  main();
+}


### PR DESCRIPTION
## Summary

Closes #779. Second pull from Epic #791 (pre-v10 hardening).

Catches the kind of drift fixed in v9.20.4 (29 doc drifts in one shot) before it accumulates again. Same drift pattern bit us this past session — the issue body for #797 / #798 / #799 referenced `ernesto-*` skills that had been renamed to `soleri-*`, so the tracker was wrong about what work remained. A doc-drift CI catches that class of bug at PR time.

## What's in here

- **`scripts/check-docs-drift.ts`** — runner with 4 detectors, plain Node built-ins (no new deps)
- **`scripts/check-docs-drift.test.ts`** — 24 unit tests (synthetic source + doc fixtures plus a regression check that current `main` is drift-free)
- **`.github/workflows/doc-drift.yml`** — runs on every push + PR, 5-minute timeout
- **`package.json`** — adds `docs:check-drift` and `docs:check-drift:test` scripts

## Detectors

| # | Source-of-truth | Doc target | Convention |
|---|---|---|---|
| 1 | `TONES` / `ENGINE_PROFILES` / `SETUP_TARGETS` in `packages/forge/src/agent-schema.ts` | `agent-yaml-reference.md` | `**Values:** \`a\` \| \`b\` \| \`c\`` lines |
| 2 | `packages/cli/src/commands/*.ts` filenames | `cli-reference.md` | `### <command>` sections under `## Commands` |
| 3 | `PROFILE_MODULES.full.length` in `packages/core/src/engine/module-registry.ts` | `agent-yaml-reference.md` | `All N modules` claims |
| 4 | `PROFILE_MODULES.{minimal,standard}` | `agent-yaml-reference.md` profile table | Handles `+ delta` notation for additive `standard` rows |

Each drift report names `file:line` plus expected vs. actual values, ordered for readability.

## Test plan

- [x] `npm run docs:check-drift` against current main — `no drift detected`
- [x] `npm run docs:check-drift:test` — 24 / 24 pass
- [x] `npx oxfmt --check` on script files — clean
- [x] Detectors hand-verified by mutating fixtures and confirming the right drift fires

## Acceptance check

- [x] Drift report identifies file, line, divergent value (doc vs source)
- [x] At least 4 drift detectors implemented
- [x] No new dependencies
- [x] Tests follow the 4 vault quality gates (no manifests, no tautologies, no happy-path-only, no weak assertions — each negative case asserts a specific drift detector and value)
- [x] Workflow runs in well under 60s on a no-drift PR (script execution is ~50ms locally; CI overhead is checkout + npm ci)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated documentation validation system to detect and report inconsistencies between documentation and source code.
  * Set up CI pipeline to run documentation drift checks on all pull requests and pushes to main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->