### PR TITLE
docs: add v9 to v10 (1.0.0) breaking-change migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ npx --yes soleri doctor                # Check system health
 
 > **npx vs global install:** The commands above use `npx --yes` which downloads and runs the CLI without a global install. The `--yes` flag skips the confirmation prompt. If you prefer a persistent install, run `npm install -g soleri` and then use bare `soleri` commands (e.g. `soleri create my-agent`).
 
+> **Upgrading from v9.x?** See the [v9 → v10 migration guide](src/content/docs/docs/migration/v10.md) for breaking changes and migration steps (auto-ops opt-in, plan fast-path, Zod v4 adjustments, etc.).
+
 Your agent is ready the moment it's created. No build step needed.
 
 ### Persona System

--- a/src/content/docs/docs/migration/v10.md
+++ b/src/content/docs/docs/migration/v10.md
@@ -1,0 +1,257 @@
+---
+title: v9 → v10 (1.0.0) Migration Guide
+description: Breaking changes from the v9.x line and how to migrate.
+---
+
+This guide covers every breaking change in the v9.x line that ships in **v10 / 1.0.0**. Each entry tells you what changed, why, and how to migrate, with before/after examples and the originating release.
+
+If you are on **v9.0.x – v9.6.x**, walk this guide top-to-bottom. If you are on **v9.20.x or later**, only the items in [Recent (v9.22+)](#recent-v922) are likely to affect you.
+
+## At a glance
+
+| Area | Change | Default behavior in v10 | Originating release |
+| ---- | ------ | ----------------------- | ------------------- |
+| Removed feature | Salvador retired | Salvador-tagged playbooks/flows do not load | [v9.17.0](https://github.com/adrozdenko/soleri/releases/tag/v9.17.0) |
+| Removed feature | `INTENT_TO_FLOW` static map | Replaced by dynamic `triggers.modes` scan | [v9.17.0](https://github.com/adrozdenko/soleri/releases/tag/v9.17.0) |
+| Removed feature | Cognee vector backend | Replaced by SQLite FTS5 + embeddings | [v9.3.0](https://github.com/adrozdenko/soleri/releases/tag/v9.3.0) |
+| Dependency | Zod v3 → Zod v4 | `.default({})` on object schemas with inner defaults requires a typed default | [v9.20.0](https://github.com/adrozdenko/soleri/releases/tag/v9.20.0), [v9.22.0](https://github.com/adrozdenko/soleri/releases/tag/v9.22.0) |
+| Engine config | `engine.profile` introduced | Defaults to `full` (backward-compatible) | [v9.18.0](https://github.com/adrozdenko/soleri/releases/tag/v9.18.0) |
+| Session lifecycle | `engine.autoOps.{dream, selfHeal, orphanReaper, staleClose, captureSessions}` | All default `false` (was implicit `true`) | [#796](https://github.com/adrozdenko/soleri/pull/796), [#808](https://github.com/adrozdenko/soleri/pull/808) |
+| Plan lifecycle | Trivial-plan fast-path | `orchestrate_plan` auto-approves and executes plans with prompt < 1000 chars and ≤ 3 tasks | [#795](https://github.com/adrozdenko/soleri/pull/795) |
+| Plan lifecycle | `gradeMinTaskCount` | Plans with fewer than 5 tasks skip the grade gate | [#809](https://github.com/adrozdenko/soleri/pull/809) |
+| Plan lifecycle | `injectTasks` opt-in | `create_plan` no longer injects matched-playbook task templates by default | [#810](https://github.com/adrozdenko/soleri/pull/810) |
+| Memory | Session auto-capture opt-in | Transcript hook does not write `type=session` rows unless `engine.autoOps.captureSessions: true` | [#811](https://github.com/adrozdenko/soleri/pull/811) |
+| Observability | `op:plan_reap`, `op:pipeline_metrics` | New ops; not breaking, but worth knowing | [#811](https://github.com/adrozdenko/soleri/pull/811), [#816](https://github.com/adrozdenko/soleri/pull/816) |
+
+## Recent (v9.22+)
+
+These are the changes most likely to affect agents already on the recent v9 line. Walk these first if you are upgrading from v9.20 or later.
+
+### `engine.autoOps.*` flags default to `false`
+
+**What changed.** The four session-start maintenance ops (`dream`, `selfHeal`, `orphanReaper`, `staleClose`) and the new `captureSessions` flag all default to disabled. Previously their behavior was implicit and on.
+
+**Why.** Session start was firing fire-and-forget side effects that surprised operators — the orphan reaper could close 2-hour-old plans, dream consolidations ran without warning. The transcript capture hook was also writing one `type=session` row per session, producing a 1440:1 noise ratio in the `memories` table.
+
+**Before:**
+
+```yaml
+# v9.x — auto-ops ran automatically; nothing to configure
+engine:
+  learning: true
+```
+
+**After:**
+
+```yaml
+# v10 — opt in to whichever maintenance ops you want
+engine:
+  learning: true
+  autoOps:
+    dream: true            # auto-consolidate memories on session start
+    selfHeal: true         # heal vault inconsistencies
+    orphanReaper: true     # close orphaned worktrees
+    staleClose: true       # auto-complete plans past their TTL
+    captureSessions: true  # write type=session rows from the transcript hook
+```
+
+**Migration steps.**
+
+1. If you relied on any auto-op, add it under `engine.autoOps` with `true`.
+2. The transcript capture hook (`scripts/transcript-capture-hook.sh`) now derives the agent dir from the vault path, so the new `captureSessions` flag works automatically once set.
+
+### Trivial-plan fast-path on `orchestrate_plan`
+
+**What changed.** `orchestrate_plan` auto-approves and starts execution when the plan's prompt is under 1000 characters and `tasks.length` is 3 or fewer.
+
+**Why.** The plan/approve/execute round-trip was 50:1 ceremony for one-line bug fixes. The fast-path collapses small work into a single call.
+
+**Before:**
+
+```ts
+// v9.x — plan came back in draft; you had to approve + execute separately
+const { plan } = await op('orchestrate_plan', { prompt, tasks: smallList });
+await op('approve_plan', { planId: plan.id });
+await op('orchestrate_execute', { planId: plan.id });
+```
+
+**After:**
+
+```ts
+// v10 — small plans land in 'executing' immediately
+const { plan } = await op('orchestrate_plan', { prompt, tasks: smallList });
+// plan.status === 'executing' already
+```
+
+**Migration steps.**
+
+- If your code calls `approve_plan` after `orchestrate_plan`, check the returned `plan.status` and skip the approve step when it is already `executing`.
+- If you genuinely want the old draft → approve → execute flow (e.g., to pause for review), pass **4+ tasks** or a prompt over 1000 characters to opt out of the fast-path.
+
+### `gradeMinTaskCount` skips grade gate on small plans
+
+**What changed.** `Planner.approve()` no longer runs the 8-pass gap analysis when `plan.tasks.length` is below `gradeMinTaskCount` (default `5`).
+
+**Why.** Gap analysis is wrong-sized for trivial plans — it fails them on missing alternatives or thin decisions even when the work is unambiguous.
+
+**Before:**
+
+```ts
+// v9.x — grade gate fired on every plan regardless of size
+const planner = new Planner(path, { minGradeForApproval: 'A' });
+planner.grade(planId);
+planner.approve(planId);  // throws PlanGradeRejectionError for thin plans
+```
+
+**After:**
+
+```ts
+// v10 — gate only fires at >=5 tasks; smaller plans approve unconditionally
+const planner = new Planner(path);  // default gradeMinTaskCount: 5
+planner.grade(planId);
+planner.approve(planId);  // succeeds for plans with <5 tasks even at grade F
+
+// To restore the old behavior:
+const strictPlanner = new Planner(path, { gradeMinTaskCount: 0 });
+```
+
+**Migration steps.**
+
+- Tests asserting grade rejection on empty/sparse plans must construct their `Planner` with `gradeMinTaskCount: 0`.
+- Workflows that *want* grading on small plans should set `gradeMinTaskCount: 1` (or `0` for everything).
+
+### `create_plan` no longer auto-injects playbook tasks
+
+**What changed.** Matched playbook *metadata* still appears in the response, but playbook task templates are not appended to the plan and the playbook executor session does not start unless the caller passes `injectTasks: true`.
+
+**Why.** Auto-injection added 3–5 generic tasks ("deploy", "test in production", "create PR") to ~80% of plans, regardless of whether the work fit the playbook.
+
+**Before:**
+
+```ts
+// v9.x — playbook tasks merged into the plan + executor session started
+const res = await op('create_plan', { objective, scope, tasks: userTasks });
+// res.playbook.tasksInjected might be > 0
+```
+
+**After:**
+
+```ts
+// v10 — only userTasks land in the plan unless you explicitly opt in
+const res = await op('create_plan', {
+  objective,
+  scope,
+  tasks: userTasks,
+  injectTasks: true,  // ← restores prior behavior
+});
+```
+
+**Migration steps.** Add `injectTasks: true` anywhere you depend on playbook tasks being merged in.
+
+## Plan lifecycle and observability
+
+### New `op:plan_reap` and `session_start.stalePlans`
+
+**What changed.** New `op:plan_reap` (admin facade, `auth: write`) takes a `planId` and force-completes a single plan with `reconciliation.summary = "reaped (previous: <status>)"`. `session_start` always returns `stalePlans: { count, ids }` — plans stuck in `executing` / `validating` / `reconciling` / `brainstorming` past `executingTtlMs` (default 24h). `admin_health` includes the same field.
+
+**Why.** Plans in active states had no expiry and accumulated forever after a crash or forgotten reconcile. The auto-`closeStale` sweep is gated behind `engine.autoOps.staleClose` and silently force-completes everything; `plan_reap` is the explicit, single-plan, operator-driven alternative.
+
+**Migration steps.** None — purely additive. New tools become available; nothing is removed or repurposed.
+
+### New `op:pipeline_metrics`
+
+**What changed.** Admin facade gains `op:pipeline_metrics` that aggregates per-plan signals (`objective_len`, `task_count`, `vault_search_ms`, `grade_score`, `regrade_count`) over a configurable window (default `days: 7`). Backed by a new `friction_metrics` table populated automatically on `create_plan` and `approve_plan`.
+
+**Migration steps.** None — purely additive. The table is created on schema initialization; no manual migration needed.
+
+## Removed features
+
+### Salvador retired
+
+**What changed.** All Salvador-tagged playbooks, flows, and steps were removed. Workflows that listed Salvador as a `needs:` capability are stripped or rewritten to MCP facade ops.
+
+**Why.** Salvador (the prior planning engine) was superseded by the Soleri planning module; keeping both was costing maintenance with no remaining users.
+
+**Migration steps.**
+
+- Remove any `needs: salvador` declarations from custom workflow YAML.
+- If you imported Salvador-only types or helpers, replace them with the equivalent `@soleri/core` planning types (`Planner`, `Plan`, `PlanTask`).
+- Salvador-prefixed knowledge packs (`salvador-craft`, `salvador-engineering`, `salvador-ui-pro`) still install but ship as historical knowledge — they no longer drive workflows.
+
+### `INTENT_TO_FLOW` static map removed
+
+**What changed.** The `INTENT_TO_FLOW` constant that mapped `BUILD` / `FIX` / `REVIEW` to specific flow IDs was deleted. The flow router now scans `triggers.modes` on each registered flow.
+
+**Migration steps.** If you imported `INTENT_TO_FLOW` directly, replace the lookup with `runtime.flows.matchByIntent(intent)` (or its equivalent in your code path). Flow files now declare their own intents under `triggers.modes`.
+
+### Cognee vector backend removed
+
+**What changed.** Cognee integration was removed in v9.3.0. The vault uses SQLite FTS5 with TF-IDF scoring exclusively, with optional vector embeddings for semantic search.
+
+**Migration steps.** If your `agent.yaml` or environment still references Cognee endpoints, delete those entries. No external services are required.
+
+## Dependency changes
+
+### Zod v3 → Zod v4
+
+**What changed.** Two patterns commonly break under Zod v4 (the engine bundles v4 since v9.20.0):
+
+1. **`.default({})` on object schemas with inner field defaults.** Zod v4 requires the default value to match the *full* output type, not the input type. An empty object literal no longer satisfies a schema whose fields have `.default(...)` of their own.
+2. **`z.record()` signature.** Now requires both key and value schemas: `z.record(z.string(), z.boolean())` instead of `z.record(z.boolean())`.
+
+**Before:**
+
+```ts
+// v9.x — fine under Zod v3
+const AutoOpsConfigSchema = z
+  .object({
+    dream: z.boolean().optional().default(false),
+    selfHeal: z.boolean().optional().default(false),
+  })
+  .optional()
+  .default({});
+
+const RouteMap = z.record(z.string());
+```
+
+**After:**
+
+```ts
+// v10 — typed default + 2-arg z.record
+const AutoOpsConfigSchema = z
+  .object({
+    dream: z.boolean().optional().default(false),
+    selfHeal: z.boolean().optional().default(false),
+  })
+  .optional()
+  .default({ dream: false, selfHeal: false });
+
+const RouteMap = z.record(z.string(), z.string());
+```
+
+**Migration steps.** Search for `.default({})` and `z.record(` in your custom Zod schemas. Provide an explicit typed default for any object schema whose inner fields supply their own `.default(...)`.
+
+## Removing internal artifacts
+
+The v9.x line carried a few internal labels and migration shims that are gone in v10:
+
+- The internal `v7` label on `soleri agent status` output was removed in [v9.11.0](https://github.com/adrozdenko/soleri/releases/tag/v9.11.0). External consumers should rely on `package.json` version, not the status string.
+- `WorkflowToolsSchema` was removed in [v9.9.0](https://github.com/adrozdenko/soleri/releases/tag/v9.9.0). Use the live ops registry (`runtime.opsRegistry`) as the source of truth instead.
+- The `embeddings` barrel export at `packages/core/src/embeddings/index.ts` was removed in [v9.12.1](https://github.com/adrozdenko/soleri/releases/tag/v9.12.1). Import from `@soleri/core/embedding` directly.
+
+## Verification
+
+After upgrading, run:
+
+```bash
+# Confirm your agent.yaml parses under the new schema
+npx soleri agent validate
+
+# Confirm CLAUDE.md has the right shape
+npx soleri agent status
+
+# Optional — see ceremony metrics over the last week
+npx soleri vault inspect "ernesto_admin op:pipeline_metrics params:{days:7}"
+```
+
+If anything looks off, the [Doctor command](/docs/cli-reference#doctor) reports common upgrade issues with suggested fixes.


### PR DESCRIPTION
## Summary

Closes #783. Third pull from Epic #791 (pre-v10 hardening). Docs-only — covers every v9.x breaking change still in flight in **v10 / 1.0.0**.

## What's in here

- **`src/content/docs/docs/migration/v10.md`** — the migration guide
- **`README.md`** — link to the guide near the install section, called out for v9.x upgraders

## Coverage

Each entry includes: what changed, why, before/after code, migration steps, originating release/PR.

| Area | Items |
| ---- | ----- |
| Recent (v9.22+) | `engine.autoOps` opt-in, trivial-plan fast-path, `gradeMinTaskCount`, `injectTasks` opt-in |
| Plan lifecycle | `op:plan_reap`, `session_start.stalePlans`, `op:pipeline_metrics` (additive but worth knowing) |
| Removed | Salvador, `INTENT_TO_FLOW`, Cognee |
| Dependency | Zod v3 → v4 (`.default({})` typed-defaults, `z.record(K, V)` 2-arg) |
| Removed internal | `v7` status label, `WorkflowToolsSchema`, embeddings barrel |

Each major item links to the originating release on GitHub (v9.17.0, v9.18.0, v9.20.0, v9.22.0) or the originating PR (#795, #796, #808, #809, #810, #811, #816). The Verification section ends with three concrete commands (`agent validate`, `agent status`, `op:pipeline_metrics`) so upgraders can confirm a clean cut over.

## Test plan

- [x] `npm run docs:check-drift` — clean (no drift introduced by the new doc)
- [x] `npm run docs:check-drift:test` — 24 / 24 still pass
- [x] Manual review — every breaking change cross-referenced against `gh release view` notes for the originating version

## Acceptance check

- [x] Every v9.x breaking change listed with what/why/migration/example
- [x] README links to the migration guide near the install section
- [x] Each entry references an originating release or commit/PR
- [x] No code changes outside the linked files
