### PR TITLE
fix(core/tests): make orphan-reaper path assertion platform-correct

### DIFF
--- a/packages/core/src/runtime/facades/orchestrate-facade.test.ts
+++ b/packages/core/src/runtime/facades/orchestrate-facade.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { Vault } from '../../vault/vault.js';
 import { Planner } from '../../planning/planner.js';
@@ -178,7 +178,9 @@ describe('orchestrate-facade', () => {
 
     const result = await executeOp(rtOps, 'session_start', { projectPath: '/test/orphans' });
     expect(result.success).toBe(true);
-    await vi.waitFor(() => expect(worktreeReap).toHaveBeenCalledWith('/test/orphans'));
+    // session_start resolves projectPath before passing it on; resolve() here
+    // keeps the assertion correct on Windows (drive-prefixed absolute paths).
+    await vi.waitFor(() => expect(worktreeReap).toHaveBeenCalledWith(resolve('/test/orphans')));
   });
 
   it('session_start auto-closes stale plans and reports count', async () => {


### PR DESCRIPTION
## Problem

The **windows-latest** test job has been failing on every PR since #808 landed, blocking the entire merge queue (all 10 open dependabot PRs fail this same job — even docs-only and markdownlint-only changes).

Single failing test:
`orchestrate-facade.test.ts > session_start runs orphan reaper when engine.autoOps.orphanReaper is true`

## Root cause

`session_start` resolves `projectPath` via `path.resolve()` before calling `worktreeReap` (orchestrate-facade.ts:45). The test asserted the literal POSIX string `'/test/orphans'`, which only matches on POSIX platforms. On Windows, `resolve('/test/orphans')` yields `C:\\test\\orphans`, so the mock assertion fails.

## Fix

Wrap the expected value in `resolve()` so the assertion mirrors the implementation's platform behavior. Implementation behavior is unchanged — resolving to an absolute path is correct.

## Verification

- All 19 tests in the file pass locally (macOS).
- The windows-latest job on this PR is the authoritative check — it could not pass before this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Windows path handling in test assertions for better cross-platform compatibility testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->