### PR TITLE
fix(forge/skills): remove 'ingest this' trigger collision between intake and knowledge-harvest

### DIFF
--- a/packages/forge/src/skills/soleri-knowledge-harvest/SKILL.md
+++ b/packages/forge/src/skills/soleri-knowledge-harvest/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: soleri-knowledge-harvest
 tier: default
-description: 'Triggers: "learn from this", "harvest knowledge", "ingest this", "extract patterns from". Bulk-extracts patterns from code/docs/PRs/articles into vault. Use vault-capture for single patterns.'
+description: 'Triggers: "learn from this", "harvest knowledge", "harvest this codebase", "extract patterns from". Bulk-extracts patterns from code/docs/PRs/articles into vault. Use vault-capture for single patterns, intake for ingesting external sources.'
 ---
 
 # Knowledge Harvest — Extract Patterns From Anything


### PR DESCRIPTION
## Context

Issue #798 proposed merging the vault-capture/intake/knowledge-harvest skill variants 4→1. Investigation (see issue comment) found only 3 variants exist and they serve genuinely distinct workflows — gated single-pattern capture vs external-source ingestion vs retrospective bulk extraction. Merging them would produce one 20+ step skill with conditional branching and break user expectations ('ingest this URL' is auto; 'save to vault' requires approval).

The real defect behind the issue is a **trigger collision**: both `soleri-intake` and `soleri-knowledge-harvest` claimed "ingest this", making intent routing ambiguous.

## Change

- `soleri-knowledge-harvest`: trigger "ingest this" → "harvest this codebase"; description now cross-references intake for external sources.

## Verification

- `npm run validate-skills` — no findings for this file
- `e2e/skill-trigger-coverage.test.ts` — 9/9 pass

Closes #798