### PR TITLE
chore(e2e): prune manifest duplicates and strengthen weak assertions

### DIFF
--- a/e2e/agent-simulation.test.ts
+++ b/e2e/agent-simulation.test.ts
@@ -153,8 +153,11 @@ describe('Agent Simulation: First Week', () => {
       const brain = res.brain as { vocabularySize: number; feedbackCount: number };
       expect(brain.vocabularySize).toBe(0);
       expect(brain.feedbackCount).toBe(0);
-      // LLM status is returned
-      expect(res.llm).toBeDefined();
+      // LLM status reports per-provider key availability (llmClient.isAvailable())
+      expect(res.llm).toEqual({
+        openai: expect.any(Boolean),
+        anthropic: expect.any(Boolean),
+      });
       // Curator is initialized
       expect((res.curator as { initialized: boolean }).initialized).toBe(true);
     });
@@ -175,8 +178,13 @@ describe('Agent Simulation: First Week', () => {
         'admin_reset_cache',
         'admin_diagnostic',
       ]);
-      // Routing hints are always present
-      expect(res.routing).toBeDefined();
+      // Routing hints map intent phrases to facade.op, built from
+      // ENGINE_MODULE_MANIFEST intentSignals (buildRoutingHints)
+      expect(res.routing).toMatchObject({
+        'search knowledge': 'vault.search_intelligent',
+        'plan this': 'plan.create_plan',
+        'recall past work': 'memory.memory_search',
+      });
     });
 
     it('3. Vault has exactly the seeded playbooks at start', async () => {
@@ -190,10 +198,16 @@ describe('Agent Simulation: First Week', () => {
       const res = await op('brain', 'brain_stats');
 
       expect(res.feedbackCount).toBe(0);
-      expect(res.intelligence).toBeDefined();
-      const intel = res.intelligence as { sessions: number; strengths: number };
-      expect(intel.sessions).toBe(0);
-      expect(intel.strengths).toBe(0);
+      // Fresh brain: every BrainIntelligenceStats counter starts at zero
+      expect(res.intelligence).toEqual({
+        strengths: 0,
+        sessions: 0,
+        activeSessions: 0,
+        proposals: 0,
+        promotedProposals: 0,
+        globalPatterns: 0,
+        domainProfiles: 0,
+      });
     });
 
     it('5. Route intent — "what can you do?" should classify as general (no matching keywords)', async () => {

--- a/e2e/comprehensive-features.test.ts
+++ b/e2e/comprehensive-features.test.ts
@@ -504,17 +504,27 @@ describe('Design: data-serving ops', () => {
     'get_stack_guidelines',
   ];
 
-  for (const opName of dataOps) {
-    it(`${opName} returns data with correct source`, async () => {
+  it('every data-serving op returns populated intelligence data without errors', async () => {
+    for (const opName of dataOps) {
       const op = findOp('design', opName);
       const result = (await op.handler({ query: 'test', topic: 'general' })) as {
         source: string;
-        data: unknown;
+        data: Record<string, unknown>;
+        error?: unknown;
       };
-      expect(result.source).toBe(opName);
-      expect(result.data).toBeDefined();
-    });
-  }
+      // Each op echoes its own name as source and serves a non-empty JSON
+      // section loaded from the pack's bundled data files — an empty object
+      // means the data file is missing or corrupt.
+      expect(result.source, `${opName} source`).toBe(opName);
+      expect(result.error, `${opName} must not return an error`).toBeUndefined();
+      expect(result.data, `${opName} data must be a non-null object`).toBeTypeOf('object');
+      expect(result.data, `${opName} data must not be null`).not.toBeNull();
+      expect(
+        Object.keys(result.data).length,
+        `${opName} data must have at least one property`,
+      ).toBeGreaterThan(0);
+    }
+  });
 });
 
 // =========================================================================
@@ -540,17 +550,26 @@ describe('Design Rules: all 15 ops return data', () => {
     'get_error_handling_patterns',
   ];
 
-  for (const opName of ruleOps) {
-    it(`${opName} returns non-empty response`, async () => {
-      const facade = facades.find((f) => f.name.includes('design_rules'));
-      expect(facade).toBeDefined();
-      const op = facade!.ops.find((o) => o.name === opName);
-      expect(op).toBeDefined();
-      const result = (await op!.handler({ topic: 'all' })) as { source: string; data: unknown };
-      expect(result.source).toBe(opName);
-      expect(result.data).toBeDefined();
-    });
-  }
+  it('every rules op returns populated rules data without errors', async () => {
+    for (const opName of ruleOps) {
+      const op = findOp('design_rules', opName);
+      const result = (await op.handler({ topic: 'all' })) as {
+        source: string;
+        data: Record<string, unknown>;
+        error?: unknown;
+      };
+      // Each rules op serves a non-empty JSON section from the pack's bundled
+      // data files — an empty object means the data file is missing or corrupt.
+      expect(result.source, `${opName} source`).toBe(opName);
+      expect(result.error, `${opName} must not return an error`).toBeUndefined();
+      expect(result.data, `${opName} data must be a non-null object`).toBeTypeOf('object');
+      expect(result.data, `${opName} data must not be null`).not.toBeNull();
+      expect(
+        Object.keys(result.data).length,
+        `${opName} data must have at least one property`,
+      ).toBeGreaterThan(0);
+    }
+  });
 });
 
 // =========================================================================

--- a/e2e/full-pipeline.test.ts
+++ b/e2e/full-pipeline.test.ts
@@ -90,31 +90,8 @@ describe('E2E: full-pipeline', () => {
     return parseResponse(raw);
   }
 
-  // --- Facade Registration ---
-
-  it('should register all 24 facades (22 semantic + 2 domain)', () => {
-    expect(facades.length).toBe(24);
-    expect(handlers.size).toBe(24);
-  });
-
-  it('should have correct facade names', () => {
-    const names = facades.map((f) => f.name);
-    expect(names).toContain(`${AGENT_ID}_vault`);
-    expect(names).toContain(`${AGENT_ID}_plan`);
-    expect(names).toContain(`${AGENT_ID}_brain`);
-    expect(names).toContain(`${AGENT_ID}_memory`);
-    expect(names).toContain(`${AGENT_ID}_admin`);
-    expect(names).toContain(`${AGENT_ID}_curator`);
-    expect(names).toContain(`${AGENT_ID}_loop`);
-    expect(names).toContain(`${AGENT_ID}_orchestrate`);
-    expect(names).toContain(`${AGENT_ID}_control`);
-
-    expect(names).toContain(`${AGENT_ID}_context`);
-    expect(names).toContain(`${AGENT_ID}_agency`);
-    expect(names).toContain(`${AGENT_ID}_chat`);
-    expect(names).toContain(`${AGENT_ID}_frontend`);
-    expect(names).toContain(`${AGENT_ID}_backend`);
-  });
+  // Facade registration manifest checks live in debug-facades.test.ts —
+  // this suite exercises the facades behaviorally instead.
 
   // --- Vault Facade ---
 

--- a/e2e/planning-orchestration.test.ts
+++ b/e2e/planning-orchestration.test.ts
@@ -130,8 +130,8 @@ describe('E2E: planning-orchestration', () => {
         playbook?: { sessionId: string | null };
       };
       expect(data.created).toBe(true);
-      expect(data.plan.id).toBeDefined();
-      expect(data.plan.id).toMatch(/^plan-/);
+      // plan-lifecycle.ts generates ids as `plan-${Date.now()}-${randomBytes(4).toString('hex')}`
+      expect(data.plan.id).toMatch(/^plan-\d{13}-[0-9a-f]{8}$/);
       expect(data.plan.objective).toContain('authentication');
       expect(data.plan.status).toBe('draft');
       expect(data.plan.tasks.length).toBeGreaterThanOrEqual(3);


### PR DESCRIPTION
## Summary

Surgical follow-up to the e2e assertion-quality audit. 93% of the suite was classified healthy; this PR handles the remainder — 2 prunes and 3 strengthens across 4 files. Refs #781.

## Prunes (assert nothing behavioral)

| File | Change |
|------|--------|
| `e2e/full-pipeline.test.ts` | Deleted the 2 facade-registration manifest tests (facade count + name list) — exact duplicates of `debug-facades.test.ts` checks. The rest of the suite exercises those same facades behaviorally. |
| `e2e/comprehensive-features.test.ts` | Replaced the two parametrized loops ("data-serving ops" x13, "all 15 ops return data" x15) that only did `expect(result.data).toBeDefined()` with one schema-aware loop each. Same op coverage, but now each op must return its own name as `source`, no `error` flag, and a non-null data object with at least one property — an empty object (missing/corrupt bundled data file) now fails. |

## Strengthens (weak assertions upgraded against real contracts)

| File | Change |
|------|--------|
| `e2e/agent-simulation.test.ts` | `res.llm` now asserted as `{ openai, anthropic }` booleans per `llmClient.isAvailable()`; `res.routing` asserted against concrete phrase-to-`facade.op` mappings from `ENGINE_MODULE_MANIFEST` intentSignals; `res.intelligence` asserted as the full zero-valued `BrainIntelligenceStats` object for a fresh brain. |
| `e2e/planning-orchestration.test.ts` | Plan id now asserted against the exact generator format from `plan-lifecycle.ts`: `/^plan-\d{13}-[0-9a-f]{8}$/` (was `toBeDefined` + `/^plan-/`). |

## Audit items investigated, no change needed

The audit flagged error-swallowing try/catch in `agent-activation.test.ts` (~410, ~480), `cli-commands.test.ts`, and `filetree-agent.test.ts`. Inspection found no swallowed test failures:

- `agent-activation.test.ts:150` — the only catch in the file; it is a verbatim mirror of the production forge template (`packages/forge/src/templates/activate.ts` soleri.lock best-effort read), inside the test harness that replicates generated activation code. Lines 410/480 contain no try/catch and already use exact `toEqual` assertions.
- `cli-commands.test.ts:30` — the `runCli` helper catch converts `execFileSync` failures into `{stdout, stderr, exitCode}` that tests then assert on (including expected-failure cases). Removing it would break exit-code assertions.
- `filetree-agent.test.ts:110` — `afterAll` teardown ignoring `client.close()` errors; standard cleanup hygiene that cannot mask a test result.

## Test counts (default e2e suite, `vitest.config.ts`)

| | Files | Tests |
|---|---|---|
| Before | 27 | 825 |
| After | 27 | 797 |

Net -28 test entries, all from collapsing per-op `toBeDefined` loops; op coverage unchanged. Full default suite passes: **797/797**.

Refs #781