### PR TITLE
chore: clean up dead exports and knip dependency false positives

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -8,6 +8,9 @@ const config: KnipConfig = {
       ignoreDependencies: [
         '@secretlint/secretlint-rule-preset-recommend', // secretlint plugin loaded by config
       ],
+      // wrangler is fetched on demand via `npx wrangler` in deploy-docs.yml (CI-only);
+      // it is intentionally not a local devDependency.
+      ignoreBinaries: ['wrangler'],
     },
     'packages/core': {
       project: ['src/**/*.ts'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,10 +22,12 @@
         "@astrojs/sitemap": "3.7.2",
         "@astrojs/tailwind": "^6.0.2",
         "@secretlint/secretlint-rule-preset-recommend": "^11.3.1",
+        "@soleri/core": "^9.0.0",
         "@soleri/domain-code-review": "^1.0.0",
         "@soleri/domain-component": "^1.0.0",
         "@soleri/domain-design": "^1.0.0",
         "@soleri/domain-design-qa": "^1.0.0",
+        "@soleri/forge": "^9.0.0",
         "@types/node": "^25.6.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -42,7 +44,9 @@
         "ts-prune": "^0.10.3",
         "tsx": "^4.19.2",
         "typescript": "^6.0.3",
-        "vitest": "^4.1.8"
+        "vitest": "^4.1.8",
+        "yaml": "^2.8.2",
+        "zod": "^4.3.6"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -171,15 +175,6 @@
         "sitemap": "^9.0.0",
         "stream-replace-string": "^2.0.0",
         "zod": "^4.3.6"
-      }
-    },
-    "node_modules/@astrojs/sitemap/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@astrojs/starlight": {
@@ -4370,6 +4365,16 @@
         "@soleri/core": "^9.0.0"
       }
     },
+    "node_modules/@soleri/domain-code-review/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@soleri/domain-component": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@soleri/domain-component/-/domain-component-1.0.0.tgz",
@@ -4384,6 +4389,16 @@
       },
       "peerDependencies": {
         "@soleri/core": "^9.0.0"
+      }
+    },
+    "node_modules/@soleri/domain-component/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@soleri/domain-design": {
@@ -4417,6 +4432,26 @@
       },
       "peerDependencies": {
         "@soleri/core": "^9.0.0"
+      }
+    },
+    "node_modules/@soleri/domain-design-qa/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@soleri/domain-design/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@soleri/engine": {
@@ -4855,6 +4890,37 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.8",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
@@ -5214,6 +5280,25 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
+      "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -5375,6 +5460,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/astro/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/astro/node_modules/zod-to-ts": {
@@ -8921,16 +9015,6 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/knip/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/lilconfig": {
@@ -14928,9 +15012,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -14963,7 +15047,8 @@
         "@clack/prompts": "^1.0.0",
         "@soleri/core": "^9.0.0",
         "@soleri/forge": "^9.0.0",
-        "commander": "^13.0.0"
+        "commander": "^13.0.0",
+        "yaml": "^2.8.2"
       },
       "bin": {
         "soleri": "dist/main.js"
@@ -14984,7 +15069,6 @@
       "version": "9.22.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "better-sqlite3": "12.10.0",
         "yaml": "^2.7.0",
         "zod": "^4.3.6"
       },
@@ -15007,7 +15091,7 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "better-sqlite3": "^12.10.0",
+        "better-sqlite3": ">=12.10.0",
         "pdf-parse": "^1.1.4"
       },
       "peerDependencies": {
@@ -15018,167 +15102,6 @@
         "@anthropic-ai/sdk": {
           "optional": true
         }
-      }
-    },
-    "packages/core/node_modules/@vitest/coverage-v8": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
-      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.4",
-        "ast-v8-to-istanbul": "^1.0.0",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.2",
-        "obug": "^2.1.1",
-        "std-env": "^4.0.0-rc.1",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/browser": "4.1.4",
-        "vitest": "4.1.4"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
-      }
-    },
-    "packages/core/node_modules/@vitest/coverage-v8/node_modules/ast-v8-to-istanbul": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
-      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.31",
-        "estree-walker": "^3.0.3",
-        "js-tokens": "^10.0.0"
-      }
-    },
-    "packages/core/node_modules/@vitest/expect": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/core/node_modules/@vitest/mocker": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@vitest/spy": "4.1.4",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "packages/core/node_modules/@vitest/pretty-format": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/core/node_modules/@vitest/runner": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@vitest/utils": "4.1.4",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/core/node_modules/@vitest/snapshot": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/utils": "4.1.4",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/core/node_modules/@vitest/spy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/core/node_modules/@vitest/utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
       }
     },
     "packages/core/node_modules/ast-v8-to-istanbul": {
@@ -15193,120 +15116,12 @@
         "js-tokens": "^10.0.0"
       }
     },
-    "packages/core/node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "packages/core/node_modules/js-tokens": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/core/node_modules/vitest": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@vitest/expect": "4.1.4",
-        "@vitest/mocker": "4.1.4",
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/runner": "4.1.4",
-        "@vitest/snapshot": "4.1.4",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.4",
-        "@vitest/browser-preview": "4.1.4",
-        "@vitest/browser-webdriverio": "4.1.4",
-        "@vitest/coverage-istanbul": "4.1.4",
-        "@vitest/coverage-v8": "4.1.4",
-        "@vitest/ui": "4.1.4",
-        "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        },
-        "vite": {
-          "optional": false
-        }
-      }
-    },
-    "packages/core/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     },
     "packages/create-soleri": {
       "version": "9.22.2",
@@ -15349,17 +15164,11 @@
       "bin": {
         "soleri-forge": "dist/index.js"
       },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.4"
+      },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "packages/forge/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "packages/soleri": {

--- a/package.json
+++ b/package.json
@@ -62,10 +62,12 @@
     "@astrojs/sitemap": "3.7.2",
     "@astrojs/tailwind": "^6.0.2",
     "@secretlint/secretlint-rule-preset-recommend": "^11.3.1",
+    "@soleri/core": "^9.0.0",
     "@soleri/domain-code-review": "^1.0.0",
     "@soleri/domain-component": "^1.0.0",
     "@soleri/domain-design": "^1.0.0",
     "@soleri/domain-design-qa": "^1.0.0",
+    "@soleri/forge": "^9.0.0",
     "@types/node": "^25.6.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
@@ -82,7 +84,9 @@
     "ts-prune": "^0.10.3",
     "tsx": "^4.19.2",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.8",
+    "yaml": "^2.8.2",
+    "zod": "^4.3.6"
   },
   "lint-staged": {
     "packages/*/src/**/*.ts": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,8 @@
     "@clack/prompts": "^1.0.0",
     "@soleri/core": "^9.0.0",
     "@soleri/forge": "^9.0.0",
-    "commander": "^13.0.0"
+    "commander": "^13.0.0",
+    "yaml": "^2.8.2"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/cli/src/commands/staging.ts
+++ b/packages/cli/src/commands/staging.ts
@@ -88,7 +88,7 @@ function parseDuration(duration: string): number | null {
   }
 }
 
-export function formatSize(bytes: number): string {
+function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
@@ -114,9 +114,7 @@ export interface StaleStagingInfo {
  * @param maxAgeMs - Maximum age in milliseconds (default: 7 days)
  * @returns Info about stale entries, or null if none found.
  */
-export function getStaleStagingInfo(
-  maxAgeMs: number = DEFAULT_MAX_AGE_MS,
-): StaleStagingInfo | null {
+function getStaleStagingInfo(maxAgeMs: number = DEFAULT_MAX_AGE_MS): StaleStagingInfo | null {
   const entries = listStaged();
   if (entries.length === 0) return null;
 
@@ -147,7 +145,7 @@ export function getStaleStagingInfo(
  * @param entries - Entries to purge (from getStaleStagingInfo().staleEntries)
  * @returns Number of entries successfully removed.
  */
-export function purgeStagingEntries(entries: StagedEntry[]): number {
+function purgeStagingEntries(entries: StagedEntry[]): number {
   let removed = 0;
   for (const entry of entries) {
     try {

--- a/packages/cli/src/hook-packs/validator.ts
+++ b/packages/cli/src/hook-packs/validator.ts
@@ -118,7 +118,7 @@ export function generateFixtures(
 /**
  * Run a hook script against a single fixture in dry-run mode.
  */
-export function runSingleDryRun(scriptPath: string, fixture: TestFixture): DryRunResult {
+function runSingleDryRun(scriptPath: string, fixture: TestFixture): DryRunResult {
   const input = JSON.stringify(fixture.payload);
   try {
     const stdout = execSync(`printf '%s' '${input.replace(/'/g, "'\\''")}' | sh "${scriptPath}"`, {

--- a/packages/cli/src/utils/checks.ts
+++ b/packages/cli/src/utils/checks.ts
@@ -105,7 +105,7 @@ export function checkNodeModules(dir?: string, format?: AgentFormat): CheckResul
   return { status: 'pass', label: 'Dependencies', detail: 'node_modules/ exists' };
 }
 
-export function checkAgentYaml(agentPath: string): CheckResult {
+function checkAgentYaml(agentPath: string): CheckResult {
   const yamlPath = join(agentPath, 'agent.yaml');
   if (!existsSync(yamlPath)) {
     return { status: 'fail', label: 'agent.yaml', detail: 'not found' };
@@ -137,7 +137,7 @@ export function checkAgentYaml(agentPath: string): CheckResult {
   }
 }
 
-export function checkInstructionsDir(agentPath: string): CheckResult {
+function checkInstructionsDir(agentPath: string): CheckResult {
   const instrDir = join(agentPath, 'instructions');
   if (!existsSync(instrDir)) {
     return {
@@ -166,7 +166,7 @@ export function checkInstructionsDir(agentPath: string): CheckResult {
   }
 }
 
-export function checkEngineReachable(): CheckResult {
+function checkEngineReachable(): CheckResult {
   if (resolveCorePackageJsonPath() !== null) {
     return { status: 'pass', label: 'Engine', detail: '@soleri/core reachable' };
   }

--- a/packages/cli/src/utils/core-resolver.ts
+++ b/packages/cli/src/utils/core-resolver.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -16,18 +16,6 @@ export function resolveCorePackageJsonPath(): string | null {
 
   const packageJsonPath = join(dirname(entryPath), '..', 'package.json');
   return existsSync(packageJsonPath) ? packageJsonPath : null;
-}
-
-export function readInstalledCoreVersion(): string | null {
-  const packageJsonPath = resolveCorePackageJsonPath();
-  if (!packageJsonPath) return null;
-
-  try {
-    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as { version?: unknown };
-    return typeof pkg.version === 'string' ? pkg.version : null;
-  } catch {
-    return null;
-  }
 }
 
 export function resolveInstalledEngineBin(): string | null {

--- a/packages/core/src/adapters/memory-sync/index.ts
+++ b/packages/core/src/adapters/memory-sync/index.ts
@@ -20,9 +20,6 @@ export type {
   SyncManifest,
 } from './types.js';
 export { DEFAULT_SYNC_CONFIG } from './types.js';
-export { ClaudeCodeMemorySyncAdapter } from './claude-code-sync.js';
-export { OpenCodeMemorySyncAdapter } from './opencode-sync.js';
-export { selectEntriesForSync } from './sync-strategy.js';
 export type { VaultMemory, VaultEntry } from './sync-strategy.js';
 
 /**

--- a/packages/core/src/brain/intelligence-proposals.ts
+++ b/packages/core/src/brain/intelligence-proposals.ts
@@ -17,7 +17,7 @@ import { AUTO_PROMOTE_THRESHOLD, AUTO_PROMOTE_PENDING_MIN } from './intelligence
 
 // ─── Proposal CRUD ────────────────────────────────────────────────
 
-export function createProposal(
+function createProposal(
   provider: PersistenceProvider,
   sessionId: string,
   rule: string,

--- a/packages/core/src/curator/schema.ts
+++ b/packages/core/src/curator/schema.ts
@@ -4,7 +4,7 @@
 
 import type { PersistenceProvider } from '../persistence/types.js';
 
-export const CURATOR_SCHEMA = `
+const CURATOR_SCHEMA = `
   CREATE TABLE IF NOT EXISTS curator_entry_state (
     entry_id TEXT PRIMARY KEY,
     status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active', 'stale', 'archived')),

--- a/packages/core/src/enforcement/adapters/index.ts
+++ b/packages/core/src/enforcement/adapters/index.ts
@@ -6,7 +6,6 @@ import { ClaudeCodeAdapter } from './claude-code.js';
 import { OpenCodeAdapter } from './opencode.js';
 
 export { ClaudeCodeAdapter } from './claude-code.js';
-export { OpenCodeAdapter } from './opencode.js';
 
 export type DetectedHost = 'claude-code' | 'opencode' | 'unknown';
 

--- a/packages/core/src/flows/chain-types.ts
+++ b/packages/core/src/flows/chain-types.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 
 // ─── Chain Definition (YAML schema) ──────────────────────────────────
 
-export const chainStepSchema = z.object({
+const chainStepSchema = z.object({
   id: z.string(),
   op: z.string().describe('Facade op to call'),
   params: z

--- a/packages/core/src/flows/types.ts
+++ b/packages/core/src/flows/types.ts
@@ -10,13 +10,13 @@ import { z } from 'zod';
 // Gate types
 // ---------------------------------------------------------------------------
 
-export const gateActionSchema = z.object({
+const gateActionSchema = z.object({
   action: z.enum(['STOP', 'BRANCH', 'CONTINUE']),
   goto: z.string().optional(),
   message: z.string().optional(),
 });
 
-export const gateSchema = z.discriminatedUnion('type', [
+const gateSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('GATE'),
     condition: z.string(),
@@ -48,7 +48,7 @@ export const gateSchema = z.discriminatedUnion('type', [
 // Step
 // ---------------------------------------------------------------------------
 
-export const flowStepSchema = z.object({
+const flowStepSchema = z.object({
   id: z.string(),
   name: z.string().optional(),
   description: z.string().optional(),

--- a/packages/core/src/governance/governance-policies.ts
+++ b/packages/core/src/governance/governance-policies.ts
@@ -21,7 +21,7 @@ interface PresetConfig {
   autoCapture: AutoCapturePolicy;
 }
 
-export const POLICY_PRESETS: Record<PolicyPreset, PresetConfig> = {
+const POLICY_PRESETS: Record<PolicyPreset, PresetConfig> = {
   strict: {
     quotas: {
       maxEntriesTotal: 200,
@@ -80,7 +80,7 @@ export const POLICY_PRESETS: Record<PolicyPreset, PresetConfig> = {
   },
 };
 
-export const DEFAULT_PRESET: PolicyPreset = 'moderate';
+const DEFAULT_PRESET: PolicyPreset = 'moderate';
 
 // ─── GovernancePolicies ─────────────────────────────────────────────
 

--- a/packages/core/src/governance/governance-proposals.ts
+++ b/packages/core/src/governance/governance-proposals.ts
@@ -20,7 +20,7 @@ export interface RawProposal {
   source: string;
 }
 
-export function mapProposal(row: RawProposal): Proposal {
+function mapProposal(row: RawProposal): Proposal {
   return {
     id: row.id,
     projectPath: row.project_path,

--- a/packages/core/src/intake/content-classifier.ts
+++ b/packages/core/src/intake/content-classifier.ts
@@ -49,7 +49,7 @@ Rules:
  * Build the classification system prompt, optionally injecting a canonical tag list.
  * When canonical tags are provided, the LLM is guided to prefer them.
  */
-export function buildClassificationPrompt(canonicalTags?: string[]): string {
+function buildClassificationPrompt(canonicalTags?: string[]): string {
   if (!canonicalTags || canonicalTags.length === 0) {
     return CLASSIFICATION_PROMPT;
   }

--- a/packages/core/src/operator/operator-context-store.ts
+++ b/packages/core/src/operator/operator-context-store.ts
@@ -527,7 +527,7 @@ export function normalizeCorrection(rule: string): NormalizedCorrection {
  * Two corrections are an undo pair when they share a topic (fuzzy substring
  * match) but have opposite directions.
  */
-export function isUndoCorrection(a: NormalizedCorrection, b: NormalizedCorrection): boolean {
+function isUndoCorrection(a: NormalizedCorrection, b: NormalizedCorrection): boolean {
   if (a.direction === b.direction) return false;
 
   // Exact match

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -37,7 +37,7 @@ export function usedLegacyFallback(agentId: string): boolean {
  * Legacy agent home: ~/.{agentId}/ (pre-v8 layout).
  * Exported for use by the migration command.
  */
-export function legacyAgentHome(agentId: string): string {
+function legacyAgentHome(agentId: string): string {
   return join(homedir(), `.${agentId}`);
 }
 

--- a/packages/core/src/planning/gap-passes.ts
+++ b/packages/core/src/planning/gap-passes.ts
@@ -10,7 +10,7 @@ import { gap, taskText, decisionText, decisionsText, containsAny } from './gap-p
 
 // ─── Pattern Constants (Passes 5-8) ─────────────────────────────
 
-export const AMBIGUOUS_WORDS = [
+const AMBIGUOUS_WORDS = [
   'maybe',
   'perhaps',
   'might',
@@ -28,13 +28,13 @@ export const AMBIGUOUS_WORDS = [
   'somehow',
 ];
 
-export const GENERIC_OBJECTIVE_PATTERNS = [
+const GENERIC_OBJECTIVE_PATTERNS = [
   /^(create|build|implement|add|make|do)\s+\w+$/i,
   /^fix\s+\w+$/i,
   /^update\s+\w+$/i,
 ];
 
-export const RATIONALE_INDICATORS = [
+const RATIONALE_INDICATORS = [
   'because',
   'since',
   'due to',
@@ -44,9 +44,9 @@ export const RATIONALE_INDICATORS = [
   'as a result',
 ];
 
-export const SHALLOW_INDICATORS = ['better', 'good', 'best', 'nice', 'great', 'improved'];
+const SHALLOW_INDICATORS = ['better', 'good', 'best', 'nice', 'great', 'improved'];
 
-export const KNOWLEDGE_INDICATORS = [
+const KNOWLEDGE_INDICATORS = [
   /vault\s*pattern/i,
   /vault\s*patterns/i,
   /anti-pattern/i,
@@ -58,7 +58,7 @@ export const KNOWLEDGE_INDICATORS = [
 ];
 
 /** Checks if task descriptions reference specific named patterns (e.g. "zod-form-validation"). */
-export const NAMED_PATTERN_REGEX = /[a-z]+-[a-z]+-[a-z]+/;
+const NAMED_PATTERN_REGEX = /[a-z]+-[a-z]+-[a-z]+/;
 
 // ─── Pass 5: Clarity ─────────────────────────────────────────────
 

--- a/packages/core/src/planning/gap-patterns.ts
+++ b/packages/core/src/planning/gap-patterns.ts
@@ -58,7 +58,7 @@ export function containsAny(text: string, patterns: string[]): boolean {
 
 // ─── Pattern Constants (Passes 1-4) ─────────────────────────────
 
-export const METRIC_PATTERNS = [
+const METRIC_PATTERNS = [
   /\d+/,
   /percent/i,
   /reduce/i,
@@ -71,7 +71,7 @@ export const METRIC_PATTERNS = [
   /benchmark/i,
 ];
 
-export const EXCLUSION_KEYWORDS = [
+const EXCLUSION_KEYWORDS = [
   'not',
   'exclude',
   'outside',
@@ -82,7 +82,7 @@ export const EXCLUSION_KEYWORDS = [
   'will not',
 ];
 
-export const OVERLY_BROAD_PATTERNS = [
+const OVERLY_BROAD_PATTERNS = [
   'everything',
   'all systems',
   'entire codebase',
@@ -92,7 +92,7 @@ export const OVERLY_BROAD_PATTERNS = [
   'rewrite everything',
 ];
 
-export const DEPENDENCY_KEYWORDS = [
+const DEPENDENCY_KEYWORDS = [
   'depends',
   'dependency',
   'prerequisite',
@@ -101,7 +101,7 @@ export const DEPENDENCY_KEYWORDS = [
   'before',
 ];
 
-export const BREAKING_CHANGE_KEYWORDS = [
+const BREAKING_CHANGE_KEYWORDS = [
   'breaking change',
   'breaking',
   'migration',
@@ -112,7 +112,7 @@ export const BREAKING_CHANGE_KEYWORDS = [
   'database migration',
 ];
 
-export const MITIGATION_KEYWORDS = [
+const MITIGATION_KEYWORDS = [
   'rollback',
   'backward compatible',
   'backwards compatible',
@@ -125,7 +125,7 @@ export const MITIGATION_KEYWORDS = [
   'blue-green',
 ];
 
-export const VERIFICATION_KEYWORDS = [
+const VERIFICATION_KEYWORDS = [
   'test',
   'verify',
   'validate',

--- a/packages/core/src/planning/plan-lifecycle.ts
+++ b/packages/core/src/planning/plan-lifecycle.ts
@@ -41,12 +41,6 @@ export const LIFECYCLE_TRANSITIONS: Record<PlanStatus, PlanStatus[]> = {
   archived: [],
 };
 
-/** Default TTL for draft/approved plans: 30 minutes. */
-export const DEFAULT_DRAFT_TTL_MS = 30 * 60 * 1000;
-
-/** Default TTL for executing/validating/reconciling plans: 24 hours. */
-export const DEFAULT_EXECUTING_TTL_MS = 24 * 60 * 60 * 1000;
-
 /**
  * Statuses where the short (draft) TTL should NOT apply.
  * Plans in these states use the longer executing TTL instead.

--- a/packages/core/src/runtime/agent-config.ts
+++ b/packages/core/src/runtime/agent-config.ts
@@ -35,7 +35,7 @@ export interface AgentConfig {
   capabilityMap?: Record<string, { facade: string; op: string }>;
 }
 
-export const DEFAULT_AUTO_OPS_CONFIG: Required<AgentAutoOpsConfig> = {
+const DEFAULT_AUTO_OPS_CONFIG: Required<AgentAutoOpsConfig> = {
   dream: false,
   selfHeal: false,
   orphanReaper: false,

--- a/packages/core/src/scheduler/platform-linux.ts
+++ b/packages/core/src/scheduler/platform-linux.ts
@@ -117,12 +117,12 @@ export function linuxTaskExists(platformId: string): boolean {
   return existsSync(unitPath(name, 'timer'));
 }
 
-export function pauseLinuxTask(platformId: string): void {
+function pauseLinuxTask(platformId: string): void {
   execFileSync('systemctl', ['--user', 'disable', `${platformId}.timer`], { stdio: 'pipe' });
   execFileSync('systemctl', ['--user', 'stop', `${platformId}.timer`], { stdio: 'pipe' });
 }
 
-export function resumeLinuxTask(platformId: string): void {
+function resumeLinuxTask(platformId: string): void {
   execFileSync('systemctl', ['--user', 'enable', '--now', `${platformId}.timer`], {
     stdio: 'pipe',
   });

--- a/packages/core/src/scheduler/platform-macos.ts
+++ b/packages/core/src/scheduler/platform-macos.ts
@@ -146,11 +146,11 @@ export function macOSTaskExists(platformId: string): boolean {
   return existsSync(plistPath(platformId));
 }
 
-export function pauseMacOSTask(platformId: string): void {
+function pauseMacOSTask(platformId: string): void {
   execFileSync('launchctl', ['unload', plistPath(platformId)], { stdio: 'pipe' });
 }
 
-export function resumeMacOSTask(platformId: string): void {
+function resumeMacOSTask(platformId: string): void {
   execFileSync('launchctl', ['load', '-w', plistPath(platformId)], { stdio: 'pipe' });
 }
 

--- a/packages/core/src/scheduler/scheduler.ts
+++ b/packages/core/src/scheduler/scheduler.ts
@@ -13,11 +13,11 @@ import { platform } from 'node:os';
 import type { PlatformAdapter, ScheduledTask, CreateTaskInput, TaskListEntry } from './types.js';
 import { validateCron, estimateMinIntervalHours } from './cron-validator.js';
 
-export const MAX_TASKS = 10;
-export const MIN_INTERVAL_HOURS = 1;
+const MAX_TASKS = 10;
+const MIN_INTERVAL_HOURS = 1;
 
 /** Resolve the platform adapter for the current OS. Throws on unsupported OS. */
-export async function resolvePlatformAdapter(): Promise<PlatformAdapter> {
+async function resolvePlatformAdapter(): Promise<PlatformAdapter> {
   const os = platform();
   if (os === 'darwin') {
     const { MacOSAdapter } = await import('./platform-macos.js');

--- a/packages/core/src/vault/vault-entries.ts
+++ b/packages/core/src/vault/vault-entries.ts
@@ -68,7 +68,7 @@ export function autoLink(entryId: string, config: AutoLinkConfig): void {
  * Best-effort: never blocks vault writes, never throws.
  * Skips when pipeline is null, disabled, or batch >100 entries.
  */
-export function autoEmbed(
+function autoEmbed(
   entryList: Array<Pick<IntelligenceEntry, 'id' | 'title' | 'description' | 'context'>>,
   config: AutoEmbedConfig,
 ): void {

--- a/packages/core/src/vault/vault-memories.ts
+++ b/packages/core/src/vault/vault-memories.ts
@@ -326,7 +326,7 @@ export function memoriesByProject(
 
 // ── Helper ──────────────────────────────────────────────────────────────
 
-export function rowToMemory(row: Record<string, unknown>): Memory {
+function rowToMemory(row: Record<string, unknown>): Memory {
   return {
     id: row.id as string,
     projectPath: row.project_path as string,

--- a/packages/core/src/vault/vault-schema.ts
+++ b/packages/core/src/vault/vault-schema.ts
@@ -257,7 +257,7 @@ function migrateTierColumn(provider: PersistenceProvider): void {
   );
 }
 
-export function migratePerformanceIndexes(provider: PersistenceProvider): void {
+function migratePerformanceIndexes(provider: PersistenceProvider): void {
   provider.execSql(`
     CREATE INDEX IF NOT EXISTS idx_memories_archived_at ON memories(archived_at);
     CREATE INDEX IF NOT EXISTS idx_entries_updated_at ON entries(updated_at);

--- a/packages/forge/package.json
+++ b/packages/forge/package.json
@@ -55,6 +55,9 @@
     "yaml": "^2.8.2",
     "zod": "^4.3.6"
   },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^4.1.4"
+  },
   "engines": {
     "node": ">=18.0.0"
   }

--- a/packages/forge/src/agent-schema.ts
+++ b/packages/forge/src/agent-schema.ts
@@ -22,7 +22,7 @@ export const ENGINE_PROFILES = ['minimal', 'standard', 'full'] as const;
 export type EngineProfile = (typeof ENGINE_PROFILES)[number];
 
 /** Where to set up client integration */
-export const SETUP_TARGETS = ['claude', 'codex', 'opencode', 'both', 'all'] as const;
+const SETUP_TARGETS = ['claude', 'codex', 'opencode', 'both', 'all'] as const;
 export type SetupTarget = (typeof SETUP_TARGETS)[number];
 
 // ─── Sub-Schemas ──────────────────────────────────────────────────────
@@ -118,30 +118,24 @@ const SetupConfigSchema = z.object({
 // ─── Workflow Sub-Schemas ─────────────────────────────────────────────
 
 /** Gate phases in a workflow */
-export const GATE_PHASES = ['brainstorming', 'pre-execution', 'post-task', 'completion'] as const;
+const GATE_PHASES = ['brainstorming', 'pre-execution', 'post-task', 'completion'] as const;
 export type GatePhase = (typeof GATE_PHASES)[number];
 
 /** Workflow gate definition (maps to gates.yaml) */
-export const WorkflowGateSchema = z.object({
+const WorkflowGateSchema = z.object({
   phase: z.enum(GATE_PHASES),
   requirement: z.string().min(1),
   check: z.string().min(1),
 });
 
 /** Task template ordering */
-export const TASK_ORDERS = ['before-implementation', 'after-implementation', 'parallel'] as const;
+const TASK_ORDERS = ['before-implementation', 'after-implementation', 'parallel'] as const;
 
 /** Task template types */
-export const TASK_TYPES = [
-  'implementation',
-  'test',
-  'story',
-  'documentation',
-  'verification',
-] as const;
+const TASK_TYPES = ['implementation', 'test', 'story', 'documentation', 'verification'] as const;
 
 /** Workflow task template (injected during plan generation) */
-export const WorkflowTaskTemplateSchema = z.object({
+const WorkflowTaskTemplateSchema = z.object({
   taskType: z.enum(TASK_TYPES),
   titleTemplate: z.string().min(1),
   acceptanceCriteria: z.array(z.string()).optional().default([]),
@@ -150,11 +144,11 @@ export const WorkflowTaskTemplateSchema = z.object({
 });
 
 /** Workflow intent types */
-export const INTENTS = ['BUILD', 'FIX', 'REVIEW', 'PLAN', 'IMPROVE', 'DELIVER'] as const;
+const INTENTS = ['BUILD', 'FIX', 'REVIEW', 'PLAN', 'IMPROVE', 'DELIVER'] as const;
 export type Intent = (typeof INTENTS)[number];
 
 /** Workflow definition (maps to workflow folder contents) */
-export const WorkflowDefinitionSchema = z.object({
+const WorkflowDefinitionSchema = z.object({
   /** Unique workflow ID (derived from folder name if not specified) */
   id: z.string().optional(),
   /** generic or domain tier */
@@ -190,7 +184,7 @@ export const WorkflowDefinitionSchema = z.object({
 // ─── Workspace & Routing Schemas ─────────────────────────────────────
 
 /** Workspace definition — scoped context area within an agent */
-export const WorkspaceSchema = z.object({
+const WorkspaceSchema = z.object({
   /** Unique workspace identifier (kebab-case) */
   id: z.string().min(1),
   /** Human-readable workspace name */
@@ -202,7 +196,7 @@ export const WorkspaceSchema = z.object({
 });
 
 /** Routing entry — maps task patterns to workspaces */
-export const RoutingEntrySchema = z.object({
+const RoutingEntrySchema = z.object({
   /** Task pattern that triggers this route (e.g., "write script", "review code") */
   pattern: z.string().min(1),
   /** Target workspace id */

--- a/packages/forge/src/templates/skills.ts
+++ b/packages/forge/src/templates/skills.ts
@@ -27,7 +27,7 @@ export interface SkillStepDef {
  * Extract optional `steps` array from YAML frontmatter.
  * Uses simple regex parsing — no YAML dependency needed.
  */
-export function extractStepsFromFrontmatter(content: string): SkillStepDef[] | null {
+function extractStepsFromFrontmatter(content: string): SkillStepDef[] | null {
   const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
   if (!fmMatch) return null;
 
@@ -84,24 +84,13 @@ export function extractStepsFromFrontmatter(content: string): SkillStepDef[] | n
 // ---------------------------------------------------------------------------
 
 /**
- * Extract the `name:` field from YAML frontmatter.
- * Returns the raw string value, or null if not found.
- */
-export function extractNameFromFrontmatter(content: string): string | null {
-  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
-  if (!fmMatch) return null;
-  const nameMatch = fmMatch[1].match(/^name:\s*(.+)/m);
-  return nameMatch ? nameMatch[1].trim().replace(/^["']|["']$/g, '') : null;
-}
-
-/**
  * Inject announce and completion feedback instructions into a skill's content.
  *
  * Announce goes immediately after the frontmatter block.
  * Complete goes at the very end of the file.
  * Both are inside HTML comments so they don't clutter the rendered output.
  */
-export function injectSkillFeedback(content: string, skillName: string): string {
+function injectSkillFeedback(content: string, skillName: string): string {
   // Count ### headings as "steps"
   const stepMatches = content.match(/^### .+/gm) ?? [];
   const stepCount = stepMatches.length;


### PR DESCRIPTION
Cleans up the 63 unused exports and 37 dependency/binary false positives from the weekly dead-code audit (Refs #805 — the weekly audit re-verifies; unused exported *types* (130) and the tokens duplicate export were not in scope for this pass).

## Workstream 1 — Unused exports (63/63 addressed)

Every symbol was verified against internal usage, unit tests, e2e suites, scripts, docs, forge template strings (generated-code references), and `@soleri/core` / `@soleri/forge` package.json `exports` entry points before acting.

### Deleted (4) — entirely unreferenced

| File | Symbol |
|------|--------|
| `packages/cli/src/utils/core-resolver.ts` | `readInstalledCoreVersion` (+ now-unused `readFileSync` import) |
| `packages/core/src/planning/plan-lifecycle.ts` | `DEFAULT_DRAFT_TTL_MS`, `DEFAULT_EXECUTING_TTL_MS` |
| `packages/forge/src/templates/skills.ts` | `extractNameFromFrontmatter` |

### Dead re-export statements removed (4) — symbols stay exported from their defining modules

| File | Re-export removed |
|------|-------------------|
| `packages/core/src/adapters/memory-sync/index.ts` | `ClaudeCodeMemorySyncAdapter`, `OpenCodeMemorySyncAdapter`, `selectEntriesForSync` |
| `packages/core/src/enforcement/adapters/index.ts` | `OpenCodeAdapter` |

Neither index module is a public entry point (`@soleri/core` `exports` has no `./adapters/memory-sync` subpath, and `./enforcement` re-exports only `ClaudeCodeAdapter`). Unit tests import these classes from their defining modules, which are untouched.

### Export keyword removed (55) — used internally, exported needlessly

- `packages/cli/src/commands/staging.ts`: `formatSize`, `getStaleStagingInfo`, `purgeStagingEntries`
- `packages/cli/src/hook-packs/validator.ts`: `runSingleDryRun`
- `packages/cli/src/utils/checks.ts`: `checkAgentYaml`, `checkInstructionsDir`, `checkEngineReachable`
- `packages/core/src/brain/intelligence-proposals.ts`: `createProposal`
- `packages/core/src/curator/schema.ts`: `CURATOR_SCHEMA`
- `packages/core/src/flows/chain-types.ts`: `chainStepSchema`
- `packages/core/src/flows/types.ts`: `gateActionSchema`, `gateSchema`, `flowStepSchema`
- `packages/core/src/governance/governance-policies.ts`: `POLICY_PRESETS`, `DEFAULT_PRESET`
- `packages/core/src/governance/governance-proposals.ts`: `mapProposal`
- `packages/core/src/intake/content-classifier.ts`: `buildClassificationPrompt`
- `packages/core/src/operator/operator-context-store.ts`: `isUndoCorrection`
- `packages/core/src/paths.ts`: `legacyAgentHome`
- `packages/core/src/planning/gap-passes.ts`: `AMBIGUOUS_WORDS`, `GENERIC_OBJECTIVE_PATTERNS`, `RATIONALE_INDICATORS`, `SHALLOW_INDICATORS`, `KNOWLEDGE_INDICATORS`, `NAMED_PATTERN_REGEX`
- `packages/core/src/planning/gap-patterns.ts`: `METRIC_PATTERNS`, `EXCLUSION_KEYWORDS`, `OVERLY_BROAD_PATTERNS`, `DEPENDENCY_KEYWORDS`, `BREAKING_CHANGE_KEYWORDS`, `MITIGATION_KEYWORDS`, `VERIFICATION_KEYWORDS`
- `packages/core/src/runtime/agent-config.ts`: `DEFAULT_AUTO_OPS_CONFIG`
- `packages/core/src/scheduler/platform-linux.ts`: `pauseLinuxTask`, `resumeLinuxTask`
- `packages/core/src/scheduler/platform-macos.ts`: `pauseMacOSTask`, `resumeMacOSTask`
- `packages/core/src/scheduler/scheduler.ts`: `MAX_TASKS`, `MIN_INTERVAL_HOURS`, `resolvePlatformAdapter`
- `packages/core/src/vault/vault-entries.ts`: `autoEmbed`
- `packages/core/src/vault/vault-memories.ts`: `rowToMemory`
- `packages/core/src/vault/vault-schema.ts`: `migratePerformanceIndexes`
- `packages/forge/src/agent-schema.ts`: `SETUP_TARGETS`, `GATE_PHASES`, `WorkflowGateSchema`, `TASK_ORDERS`, `TASK_TYPES`, `WorkflowTaskTemplateSchema`, `INTENTS`, `WorkflowDefinitionSchema`, `WorkspaceSchema`, `RoutingEntrySchema` (the public `SETUP_TARGETS` lives in `types.ts` and is re-exported via `./lib`; this was an internal duplicate)
- `packages/forge/src/templates/skills.ts`: `extractStepsFromFrontmatter`, `injectSkillFeedback`

### False positives kept (0)

None of the 63 turned out to be referenced via dynamic import, string lookup, forge template strings, or e2e/scripts, and none are re-exported from a package entry point — so all 63 could be acted on.

## Workstream 2 — knip false positives (structural fix, not ignore-list growth)

- **Root `package.json` devDependencies** now declare `@soleri/core`, `@soleri/forge`, `yaml`, `zod` — the root-workspace `e2e/` suite imports them and previously resolved them only through npm-workspace hoisting. This clears all 36 "unlisted dependency" reports without any knip ignore entries (`@soleri/core`/`@soleri/forge` resolve to the local workspace symlinks).
- **`packages/cli`** declares `yaml` as a runtime dependency (imported by `commands/agent.ts`, `commands/test.ts`, `utils/agent-context.ts`).
- **`packages/forge`** declares `@vitest/coverage-v8` as a devDependency (referenced by its vitest coverage config), mirroring `packages/core`.
- **`knip.config.ts`**: single `ignoreBinaries: ['wrangler']` on the root workspace — wrangler is fetched on demand via `npx wrangler` in `deploy-docs.yml` and is intentionally not a local devDependency.

## Verification

- `npm run build` — clean
- Unit tests: core 263/263 files (5025 tests), cli 23/23, forge 9/9
- `npm run deadcode:knip` — exit 0; `npx knip` (the weekly-audit invocation) reports **zero** unused exports, unlisted dependencies, or unlisted binaries
- `npm run deadcode:ts-prune` — clean
- `npm run lint` — 0 errors; `npm run format:check` — clean

## Worth reviewer attention

- `DEFAULT_DRAFT_TTL_MS` / `DEFAULT_EXECUTING_TTL_MS` deletion: the actual TTL enforcement lives elsewhere; these constants were never imported. If they were meant to feed the lifecycle expiry config, they should be wired in instead of restored as dead exports.
- `memory-sync` / `OpenCodeAdapter` re-export removals: safe per the current `exports` maps, but if a future pack-author API is meant to expose memory-sync adapters, they should be added to `@soleri/core`'s `exports` subpaths deliberately.
- Root devDeps on `@soleri/core`/`@soleri/forge` (`^9.0.0`): npm links the workspace copies; no registry installs were added to the lockfile for them.
