### PR TITLE
chore(deps): upgrade typescript to 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "tailwindcss": "^3.4.17",
         "ts-prune": "^0.10.3",
         "tsx": "^4.19.2",
-        "typescript": "^5.7.3",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.8"
       },
       "engines": {
@@ -5003,6 +5003,40 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/astro/node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/astro/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/astro/node_modules/zod-to-ts": {
@@ -13107,26 +13141,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -13194,9 +13208,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "tailwindcss": "^3.4.17",
     "ts-prune": "^0.10.3",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   },
   "lint-staged": {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,

--- a/packages/create-soleri/tsconfig.json
+++ b/packages/create-soleri/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,

--- a/packages/forge/tsconfig.json
+++ b/packages/forge/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,

--- a/packages/tokens/tsconfig.json
+++ b/packages/tokens/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "Node16",
     "moduleResolution": "Node16",
+    "types": ["node"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
Supersedes #778.

## Why dependabot's bump failed

TypeScript 6.0 changes the default of the `types` compiler option from auto-including **every** package found in `node_modules/@types` to an empty array (`[]`). Workspace packages here declare no `types` field and rely on implicit `@types/node` globals, so `process`, `console`, and the `NodeJS` namespace disappeared under TS 6 (TS2591 / TS2584 / TS2503 in `@soleri/cli` and `create-soleri`; `@soleri/core` only survived because `@types/better-sqlite3` transitively references `@types/node`).

## Fix

- Bump root devDep `typescript` `^5.7.3` → `^6.0.3`
- Add `"types": ["node"]` to all 5 workspace tsconfigs (cli, core, create-soleri, forge, tokens) — consistent repo-wide, resolves against the hoisted root `@types/node ^25`, zero new workspace dependencies, zero source-code changes

## Gates

| Gate | Result |
|------|--------|
| `npm run build` (all workspaces) | pass |
| `npm run typecheck` (all workspaces) | pass |
| `@soleri/core` vitest | 5025 passed |
| `@soleri/cli` vitest | 251 passed |
| `@soleri/forge` vitest | 173 passed |
| `npm run lint` | 0 errors (49 pre-existing warnings) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript to version 6.0.3.
  * Enhanced Node.js type definitions support across packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->