### PR TITLE
fix: align SKILL.md op examples with facade Zod schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,9 @@ jobs:
       - name: Lint (oxlint)
         run: npm run lint
 
+      - name: Skill doc schema validation
+        run: npm run validate-skills
+
       - name: Format check (oxfmt)
         run: npm run format:check
 

--- a/packages/core/src/skills/__tests__/validate-skill-docs.test.ts
+++ b/packages/core/src/skills/__tests__/validate-skill-docs.test.ts
@@ -2,14 +2,39 @@
  * Unit tests for the SKILL.md validator.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { validateSkillDocs } from '../validate-skill-docs.js';
 
 // Resolve monorepo root from this file's location (packages/core/src/skills/__tests__)
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 const __dirname2 = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = resolve(__dirname2, '../../../../..');
+
+/** Create a temp monorepo-shaped root with a single SKILL.md fixture. */
+function makeFixtureRoot(skillMd: string): string {
+  const root = mkdtempSync(join(tmpdir(), 'skill-docs-'));
+  const skillDir = join(root, 'packages', 'forge', 'src', 'skills', 'fixture-skill');
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, 'SKILL.md'), skillMd);
+  return root;
+}
+
+const fixtureRoots: string[] = [];
+
+function validateFixture(skillMd: string) {
+  const root = makeFixtureRoot(skillMd);
+  fixtureRoots.push(root);
+  return validateSkillDocs(root);
+}
+
+afterEach(() => {
+  while (fixtureRoots.length > 0) {
+    rmSync(fixtureRoots.pop()!, { recursive: true, force: true });
+  }
+});
 
 describe('validateSkillDocs', () => {
   it('builds a non-empty schema registry', () => {
@@ -27,22 +52,31 @@ describe('validateSkillDocs', () => {
     expect(result.totalExamples).toBeGreaterThan(20);
   });
 
-  it('returns structured error objects with file, line, opName, message', () => {
+  it('reports zero violations for the shipped SKILL.md docs', () => {
     const result = validateSkillDocs(ROOT_DIR);
-    // We expect some errors in the current state of docs
-    if (result.errors.length > 0) {
-      const err = result.errors[0];
-      expect(err).toHaveProperty('file');
-      expect(err).toHaveProperty('line');
-      expect(err).toHaveProperty('opName');
-      expect(err).toHaveProperty('message');
-      expect(typeof err.line).toBe('number');
-      expect(err.line).toBeGreaterThan(0);
-    }
+    const formatted = result.errors
+      .map((e) => `${e.file}:${e.line} — ${e.opName}: ${e.message}`)
+      .join('\n');
+    expect(result.errors, formatted).toEqual([]);
   });
 
-  it('detects the create_plan scope mismatch', () => {
-    const result = validateSkillDocs(ROOT_DIR);
+  it('returns structured error objects with file, line, opName, message', () => {
+    const result = validateFixture(
+      '```\nYOUR_AGENT_core op:update_task params: { planId: "p-1" }\n```\n',
+    );
+    expect(result.errors.length).toBeGreaterThan(0);
+    const err = result.errors[0];
+    expect(err).toHaveProperty('file');
+    expect(err).toHaveProperty('opName');
+    expect(err.opName).toBe('update_task');
+    expect(typeof err.line).toBe('number');
+    expect(err.line).toBeGreaterThan(0);
+  });
+
+  it('detects shape mismatches (create_plan scope as object)', () => {
+    const result = validateFixture(
+      '```\nYOUR_AGENT_core op:create_plan\n  params: { objective: "goal", scope: { included: ["a"] } }\n```\n',
+    );
     const scopeError = result.errors.find(
       (e) => e.opName === 'create_plan' && e.message.includes('scope'),
     );
@@ -51,8 +85,61 @@ describe('validateSkillDocs', () => {
   });
 
   it('detects unknown ops', () => {
-    const result = validateSkillDocs(ROOT_DIR);
-    const unknownOps = result.errors.filter((e) => e.message.includes('unknown op'));
-    expect(unknownOps.length).toBeGreaterThan(0);
+    const result = validateFixture(
+      '```\nYOUR_AGENT_core op:not_a_real_op params: { foo: "bar" }\n```\n',
+    );
+    const unknownOp = result.errors.find((e) => e.opName === 'not_a_real_op');
+    expect(unknownOp).toBeDefined();
+    expect(unknownOp!.message).toContain('unknown op');
+  });
+
+  it('detects missing required params', () => {
+    const result = validateFixture(
+      '```\nYOUR_AGENT_core op:merge_patterns params: { keepId: "entry-1" }\n```\n',
+    );
+    const missing = result.errors.find(
+      (e) => e.opName === 'merge_patterns' && e.message.includes('removeId'),
+    );
+    expect(missing).toBeDefined();
+  });
+
+  it('detects invalid enum values on concrete strings', () => {
+    const result = validateFixture(
+      '```\nYOUR_AGENT_core op:update_task params: { planId: "p-1", taskId: "t-1", status: "wip" }\n```\n',
+    );
+    const enumError = result.errors.find(
+      (e) => e.opName === 'update_task' && e.message.includes('status'),
+    );
+    expect(enumError).toBeDefined();
+  });
+
+  it('skips enum mismatches caused by pipe-separated placeholder values', () => {
+    const result = validateFixture(
+      '```\nYOUR_AGENT_core op:update_task params: { planId: "p-1", taskId: "t-1", status: "pending|in_progress|completed" }\n```\n',
+    );
+    expect(result.errors).toEqual([]);
+  });
+
+  it('skips placeholder enum values inside preprocessed schemas (capture_knowledge auto-wrap)', () => {
+    const result = validateFixture(
+      '```\nYOUR_AGENT_core op:capture_knowledge\n  params: { title: "t", description: "d", type: "<pattern|anti-pattern>", domain: "testing" }\n```\n',
+    );
+    expect(result.errors).toEqual([]);
+  });
+
+  it('knows ops that declare no params schema (brain_stats, loop_status)', () => {
+    const result = validateFixture(
+      '```\nYOUR_AGENT_core op:brain_stats params: { verbose: true }\nYOUR_AGENT_loop op:loop_status params: { loopId: "l-1" }\n```\n',
+    );
+    // The ops exist — they must not be reported as unknown, and with no
+    // schema there is nothing to validate params against.
+    expect(result.errors).toEqual([]);
+  });
+
+  it('registers ops from factories outside runtime/facades (core, dream)', () => {
+    const result = validateFixture(
+      '```\nYOUR_AGENT_core op:activate params: { projectPath: "." }\nYOUR_AGENT_dream op:dream_run params: { force: true }\n```\n',
+    );
+    expect(result.errors).toEqual([]);
   });
 });

--- a/packages/core/src/skills/validate-skill-docs.ts
+++ b/packages/core/src/skills/validate-skill-docs.ts
@@ -37,6 +37,8 @@ import { createLinksFacadeOps } from '../runtime/facades/links-facade.js';
 import { createBranchingFacadeOps } from '../runtime/facades/branching-facade.js';
 import { createTierFacadeOps } from '../runtime/facades/tier-facade.js';
 import { createEmbeddingFacadeOps } from '../runtime/facades/embedding-facade.js';
+import { createCoreOps, type AgentIdentityConfig } from '../engine/core-ops.js';
+import { createDreamOps } from '../dream/dream-ops.js';
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -83,10 +85,22 @@ function createNoopProxy(): AgentRuntime {
 
 // ── Schema registry ─────────────────────────────────────────────────────
 // Build a flat map of opName → ZodSchema from all facades.
+// Ops without a schema (no declared params) are registered with `null` so
+// the validator knows the op exists even though there is nothing to parse.
 
-function buildSchemaRegistry(): Map<string, OpSchema> {
+const MOCK_IDENTITY: AgentIdentityConfig = {
+  id: 'agent',
+  name: 'Agent',
+  role: 'assistant',
+  description: 'Mock identity for schema extraction',
+  domains: [],
+  principles: [],
+  tone: 'neutral',
+};
+
+function buildSchemaRegistry(): Map<string, OpSchema | null> {
   const runtime = createNoopProxy();
-  const registry = new Map<string, OpSchema>();
+  const registry = new Map<string, OpSchema | null>();
 
   const facadeFactories: Array<(rt: AgentRuntime) => OpDefinition[]> = [
     createVaultFacadeOps,
@@ -110,15 +124,16 @@ function buildSchemaRegistry(): Map<string, OpSchema> {
     createBranchingFacadeOps,
     createTierFacadeOps,
     createEmbeddingFacadeOps,
+    // Op factories that live outside runtime/facades but are exposed by agents
+    (rt: AgentRuntime) => createCoreOps(rt, MOCK_IDENTITY),
+    createDreamOps,
   ];
 
   for (const factory of facadeFactories) {
     try {
       const ops = factory(runtime);
       for (const op of ops) {
-        if (op.schema) {
-          registry.set(op.name, op.schema);
-        }
+        registry.set(op.name, op.schema ?? null);
       }
     } catch {
       // Some facades may fail with the mock runtime — skip them.
@@ -383,9 +398,10 @@ function isPlaceholderIssue(
   issue: { code: string; path: (string | number)[]; received?: unknown; message: string },
   params: Record<string, unknown>,
 ): boolean {
-  // "Invalid enum value" on a placeholder string
-  if (issue.code === 'invalid_enum_value') {
-    const received = issue.received ?? getNestedValue(params, issue.path);
+  // Enum mismatch on a placeholder string.
+  // Zod v3 uses code 'invalid_enum_value'; Zod v4 uses 'invalid_value'.
+  if (issue.code === 'invalid_enum_value' || issue.code === 'invalid_value') {
+    const received = issue.received ?? getExampleValue(params, issue.path);
     if (isPlaceholder(received)) return true;
   }
   return false;
@@ -401,9 +417,23 @@ function getNestedValue(obj: Record<string, unknown>, path: (string | number)[])
   return current;
 }
 
+/**
+ * Resolve the example value for a Zod issue path. Some schemas preprocess
+ * their input before validation (e.g. capture_knowledge auto-wraps flat
+ * params into { entries: [params] }), so issue paths may not map 1:1 onto
+ * the raw example params. Fall back to progressively shorter path suffixes.
+ */
+function getExampleValue(obj: Record<string, unknown>, path: (string | number)[]): unknown {
+  for (let i = 0; i < path.length; i++) {
+    const value = getNestedValue(obj, path.slice(i));
+    if (value !== undefined) return value;
+  }
+  return undefined;
+}
+
 function validateExamples(
   examples: OpExample[],
-  registry: Map<string, OpSchema>,
+  registry: Map<string, OpSchema | null>,
 ): ValidationError[] {
   const errors: ValidationError[] = [];
 
@@ -417,8 +447,7 @@ function validateExamples(
 
     if (!ex.parsedParams) continue;
 
-    const schema = registry.get(ex.opName);
-    if (!schema) {
+    if (!registry.has(ex.opName)) {
       // Op not found in registry — may be from a facade that failed to load,
       // or a typo in the SKILL.md. Report it.
       errors.push({
@@ -427,6 +456,12 @@ function validateExamples(
         opName: ex.opName,
         message: `unknown op — not found in any facade schema registry`,
       });
+      continue;
+    }
+
+    const schema = registry.get(ex.opName);
+    if (!schema) {
+      // Op exists but declares no params schema — nothing to validate.
       continue;
     }
 

--- a/packages/forge/src/skills/soleri-agent-dev/SKILL.md
+++ b/packages/forge/src/skills/soleri-agent-dev/SKILL.md
@@ -25,15 +25,15 @@ The vault is the authoritative source for how the agent works. Do not rely on ge
 Before reading any source file, before making any plan, before offering any advice:
 
 ```
-YOUR_AGENT_core op:search_vault_intelligent
-  params: { query: "<description of planned work>", options: { intent: "pattern" } }
+YOUR_AGENT_core op:search_intelligent
+  params: { query: "<description of planned work>", type: "pattern" }
 ```
 
 Search again with architecture-specific terms: the facade name, tool name, or subsystem being modified.
 
 ```
-YOUR_AGENT_core op:query_vault_knowledge
-  params: { type: "workflow", category: "<relevant category>" }
+YOUR_AGENT_core op:search_intelligent
+  params: { query: "<facade, tool, or subsystem name>", type: "workflow" }
 ```
 
 If initial results are sparse, search again with broader terms — synonyms, related subsystem names, parent concepts. Exhaust the vault before moving on.
@@ -43,13 +43,13 @@ Review all results. Extract file paths, module names, function references, conve
 ### Step 2: Check Brain for Proven Patterns
 
 ```
-YOUR_AGENT_core op:strengths
-  params: { days: 30, minStrength: 60 }
+YOUR_AGENT_core op:brain_strengths
+  params: { minStrength: 60, limit: 10 }
 ```
 
 ```
-YOUR_AGENT_core op:recommend
-  params: { projectPath: "." }
+YOUR_AGENT_core op:brain_recommend
+  params: { task: "<description of planned work>", limit: 5 }
 ```
 
 Check if the brain has learned anything relevant from recent sessions.
@@ -98,6 +98,7 @@ YOUR_AGENT_core op:capture_knowledge
     title: "<what was learned>",
     description: "<the pattern or anti-pattern>",
     type: "pattern",
+    domain: "<subsystem or topic>",
     tags: ["<relevant-tags>"]
   }
 ```

--- a/packages/forge/src/skills/soleri-agent-mode/SKILL.md
+++ b/packages/forge/src/skills/soleri-agent-mode/SKILL.md
@@ -22,7 +22,7 @@ Identify the verb + object in the user's message:
 
 ```
 YOUR_AGENT_control op:route_intent
-  params: { input: "<user's phrase>", context: "<current task context>" }
+  params: { prompt: "<user's phrase>" }
 ```
 
 Use this when the phrase matches 2+ intents. Skip it for obvious, unambiguous commands.

--- a/packages/forge/src/skills/soleri-brainstorming/SKILL.md
+++ b/packages/forge/src/skills/soleri-brainstorming/SKILL.md
@@ -59,8 +59,8 @@ YOUR_AGENT_core op:capture_knowledge
   params: {
     title: "<feature> — design decision",
     description: "<chosen approach, rationale, rejected alternatives>",
-    type: "decision",
-    category: "<domain>",
+    type: "principle",
+    domain: "<domain>",
     tags: ["design-decision"]
   }
 ```

--- a/packages/forge/src/skills/soleri-code-patrol/SKILL.md
+++ b/packages/forge/src/skills/soleri-code-patrol/SKILL.md
@@ -24,9 +24,9 @@ YOUR_AGENT_core op:vault_domains
 YOUR_AGENT_core op:search_intelligent
   params: { query: "<what this code does>" }
 YOUR_AGENT_core op:search
-  params: { type: "anti-pattern" }
+  params: { query: "<what this code does>", type: "anti-pattern" }
 YOUR_AGENT_core op:search
-  params: { severity: "critical" }
+  params: { query: "<what this code does>", severity: "critical" }
 YOUR_AGENT_core op:project_list_rules
 YOUR_AGENT_core op:brain_strengths
 ```

--- a/packages/forge/src/skills/soleri-curator/SKILL.md
+++ b/packages/forge/src/skills/soleri-curator/SKILL.md
@@ -49,10 +49,7 @@ If specific entries need attention:
 
 ```
 YOUR_AGENT_curator op:curator_groom
-  params: {
-    entryIds: ["<id1>", "<id2>"],
-    tags: ["<suggested-tag>"]
-  }
+  params: { entryId: "<entry-id>" }
 ```
 
 Report how many entries were updated.

--- a/packages/forge/src/skills/soleri-deep-review/SKILL.md
+++ b/packages/forge/src/skills/soleri-deep-review/SKILL.md
@@ -169,8 +169,8 @@ YOUR_AGENT_core op:capture_knowledge
   params: {
     title: "<pattern name>",
     description: "<what was found, why it matters>",
-    type: "pattern" | "anti-pattern",
-    category: "architecture",
+    type: "pattern",
+    domain: "architecture",
     tags: ["code-review", "<specific-tag>"]
   }
 ```

--- a/packages/forge/src/skills/soleri-deliver-and-ship/SKILL.md
+++ b/packages/forge/src/skills/soleri-deliver-and-ship/SKILL.md
@@ -69,6 +69,7 @@ YOUR_AGENT_core op:capture_knowledge
     title: "<what was learned>",
     description: "<the pattern or anti-pattern>",
     type: "pattern",
+    domain: "<domain>",
     tags: ["<relevant-tags>"]
   }
 ```

--- a/packages/forge/src/skills/soleri-discovery-phase/SKILL.md
+++ b/packages/forge/src/skills/soleri-discovery-phase/SKILL.md
@@ -43,8 +43,8 @@ YOUR_AGENT_core op:capture_knowledge
   params: {
     title: "<topic> — discovery finding",
     description: "<question, options considered, recommendation, rationale>",
-    type: "decision",
-    category: "<domain>",
+    type: "principle",
+    domain: "<domain>",
     tags: ["discovery", "decision"]
   }
 ```

--- a/packages/forge/src/skills/soleri-env-setup/SKILL.md
+++ b/packages/forge/src/skills/soleri-env-setup/SKILL.md
@@ -161,7 +161,7 @@ If any non-obvious steps or workarounds were needed:
 
 ```
 YOUR_AGENT_core op:capture_knowledge
-  params: { title: "<gotcha>", description: "<what happened and the fix>", type: "anti-pattern", tags: ["env-setup", "<tech-stack>"] }
+  params: { title: "<gotcha>", description: "<what happened and the fix>", type: "anti-pattern", domain: "env-setup", tags: ["env-setup", "<tech-stack>"] }
 ```
 
 ## Agent Tools Reference

--- a/packages/forge/src/skills/soleri-finishing-a-development-branch/SKILL.md
+++ b/packages/forge/src/skills/soleri-finishing-a-development-branch/SKILL.md
@@ -73,7 +73,7 @@ If tricky conflicts were resolved:
 
 ```
 YOUR_AGENT_core op:capture_knowledge
-  params: { title: "<conflict pattern>", description: "<resolution strategy>", type: "pattern", tags: ["git", "merge", "conflict-resolution"] }
+  params: { title: "<conflict pattern>", description: "<resolution strategy>", type: "pattern", domain: "git", tags: ["git", "merge", "conflict-resolution"] }
 ```
 
 ## Step 5: Branch Cleanup

--- a/packages/forge/src/skills/soleri-fix-and-learn/SKILL.md
+++ b/packages/forge/src/skills/soleri-fix-and-learn/SKILL.md
@@ -70,7 +70,7 @@ YOUR_AGENT_core op:capture_knowledge
     title: "<bug title>",
     description: "<root cause, solution, what made it hard to find>",
     type: "anti-pattern",
-    category: "<domain>",
+    domain: "<domain>",
     tags: ["<error-type>", "<component>"]
   }
 ```

--- a/packages/forge/src/skills/soleri-health-check/SKILL.md
+++ b/packages/forge/src/skills/soleri-health-check/SKILL.md
@@ -43,7 +43,7 @@ YOUR_AGENT_core op:curator_detect_duplicates
 ```
 YOUR_AGENT_core op:curator_contradictions
 YOUR_AGENT_core op:curator_resolve_contradiction
-  params: { contradictionId: "<id>" }
+  params: { id: 42, resolution: "resolved" }
 ```
 
 ### 6. Find Stale Entries

--- a/packages/forge/src/skills/soleri-intake/SKILL.md
+++ b/packages/forge/src/skills/soleri-intake/SKILL.md
@@ -21,12 +21,12 @@ Import external content (URLs, books, text, batch files) into the vault with aut
 
 Determine what the user is providing:
 
-| Type             | Use Op         | When                             |
-| ---------------- | -------------- | -------------------------------- |
-| URL              | `ingest_url`   | User pastes a web link           |
-| Book / long doc  | `ingest_book`  | PDF, long markdown, or file path |
-| Raw text         | `ingest_text`  | User pastes text directly        |
-| Multiple sources | `ingest_batch` | List of URLs or file paths       |
+| Type             | Use Op         | When                                   |
+| ---------------- | -------------- | -------------------------------------- |
+| URL              | `ingest_url`   | User pastes a web link                 |
+| Book / long doc  | `ingest_text`  | Read the file, ingest content in parts |
+| Raw text         | `ingest_text`  | User pastes text directly              |
+| Multiple sources | `ingest_batch` | List of text items with metadata       |
 
 ### Step 2: Ingest
 
@@ -41,15 +41,16 @@ YOUR_AGENT_intake op:ingest_url
   }
 ```
 
-**Book / Long Document:**
+**Book / Long Document:** read the file first, then ingest the content
+(chapter by chapter for very long documents):
 
 ```
-YOUR_AGENT_intake op:ingest_book
+YOUR_AGENT_intake op:ingest_text
   params: {
-    path: "<file path or url>",
-    title: "<document title>",
-    domain: "<domain>",
-    chunkStrategy: "chapter"
+    text: "<chapter or section content>",
+    title: "<document title — chapter name>",
+    sourceType: "documentation",
+    domain: "<domain>"
   }
 ```
 
@@ -70,11 +71,10 @@ YOUR_AGENT_intake op:ingest_text
 ```
 YOUR_AGENT_intake op:ingest_batch
   params: {
-    sources: [
-      { type: "url", value: "<url1>" },
-      { type: "url", value: "<url2>" }
-    ],
-    domain: "<domain>"
+    items: [
+      { text: "<content 1>", title: "<title 1>", sourceType: "article", domain: "<domain>" },
+      { text: "<content 2>", title: "<title 2>", sourceType: "notes", domain: "<domain>" }
+    ]
   }
 ```
 

--- a/packages/forge/src/skills/soleri-knowledge-harvest/SKILL.md
+++ b/packages/forge/src/skills/soleri-knowledge-harvest/SKILL.md
@@ -44,8 +44,8 @@ YOUR_AGENT_core op:capture_knowledge
   params: {
     title: "<clear, searchable name>",
     description: "<what it is, when to apply, why it matters>",
-    type: "<pattern|anti-pattern|decision|principle|workflow>",
-    category: "<domain>",
+    type: "<pattern|anti-pattern|rule|principle|workflow>",
+    domain: "<domain>",
     tags: ["<tag1>", "<tag2>"],
     example: "<code snippet or quote>",
     why: "<reasoning>"

--- a/packages/forge/src/skills/soleri-loop/SKILL.md
+++ b/packages/forge/src/skills/soleri-loop/SKILL.md
@@ -22,8 +22,8 @@ Run a task in a loop until a condition is met — grade threshold, promise fulfi
 YOUR_AGENT_loop op:loop_start
   params: {
     prompt: "<task description>",
-    mode: "<plan-iteration | custom>",
-    maxIterations: <number, default 10>
+    mode: "custom",
+    maxIterations: 10
   }
 ```
 
@@ -40,7 +40,6 @@ At each iteration, check status:
 
 ```
 YOUR_AGENT_loop op:loop_status
-  params: { loopId: "<loopId>" }
 ```
 
 Report progress to user:
@@ -58,7 +57,6 @@ If the user wants to stop early:
 
 ```
 YOUR_AGENT_loop op:loop_cancel
-  params: { loopId: "<loopId>", reason: "<why stopping>" }
 ```
 
 ## Exit Criteria

--- a/packages/forge/src/skills/soleri-onboard-me/SKILL.md
+++ b/packages/forge/src/skills/soleri-onboard-me/SKILL.md
@@ -31,7 +31,7 @@ YOUR_AGENT_core op:admin_vault_size
 
 ```
 YOUR_AGENT_core op:search
-  params: { severity: "critical" }
+  params: { query: "critical rules", severity: "critical" }
 ```
 
 ### 4. Key Decisions
@@ -51,7 +51,7 @@ YOUR_AGENT_core op:brain_strengths
 
 ```
 YOUR_AGENT_core op:search
-  params: { type: "anti-pattern" }
+  params: { query: "mistakes to avoid", type: "anti-pattern" }
 ```
 
 ### 7. Cross-Project Context
@@ -111,7 +111,7 @@ Show which domain packs and knowledge packs are installed. Mention `soleri pack 
 
 ```
 YOUR_AGENT_core op:capture_knowledge
-  params: { title: "Onboarding completed for <project>", description: "<key takeaways and knowledge gaps identified>", type: "workflow", tags: ["onboarding", "<project>"] }
+  params: { title: "Onboarding completed for <project>", description: "<key takeaways and knowledge gaps identified>", type: "workflow", domain: "onboarding", tags: ["onboarding", "<project>"] }
 ```
 
 Record what was covered and what gaps remain for future onboarding.

--- a/packages/forge/src/skills/soleri-parallel-execute/SKILL.md
+++ b/packages/forge/src/skills/soleri-parallel-execute/SKILL.md
@@ -114,7 +114,7 @@ For each task in the current wave:
 2. Mark as in_progress:
 
    ```
-   YOUR_AGENT_core op:update_task params:{ planId: "<id>", taskIndex: <n>, status: "in_progress" }
+   YOUR_AGENT_core op:update_task params:{ planId: "<id>", taskId: "<taskId>", status: "in_progress" }
    ```
 
 3. Gather vault context for the task:
@@ -210,7 +210,7 @@ As subagents complete, collect their results. For each completed task:
 
 1. **Mark completed:**
    ```
-   YOUR_AGENT_core op:update_task params:{ planId: "<id>", taskIndex: <n>, status: "completed" }
+   YOUR_AGENT_core op:update_task params:{ planId: "<id>", taskId: "<taskId>", status: "completed" }
    ```
 
 ### Step 4: Advance to Next Wave
@@ -255,7 +255,7 @@ Same as executing-plans — reconcile, capture knowledge, archive:
 YOUR_AGENT_core op:plan_reconcile params:{
   planId: "<id>",
   actualOutcome: "<what happened>",
-  driftItems: [{ type: "...", description: "...", impact: "...", rationale: "..." }]
+  driftItems: [{ type: "modified", description: "<what differed>", impact: "low", rationale: "<why>" }]
 }
 
 YOUR_AGENT_core op:plan_complete_lifecycle params:{

--- a/packages/forge/src/skills/soleri-research-scout/SKILL.md
+++ b/packages/forge/src/skills/soleri-research-scout/SKILL.md
@@ -106,8 +106,10 @@ Switch to scout branch, capture, switch back:
 ```
 YOUR_AGENT_branching op:vault_branch_add
   params: {
-    branch: "scout-findings",
-    entry: {
+    branchName: "scout-findings",
+    entryId: "<new-entry-id>",
+    action: "add",
+    entryData: {
       title: "{concise finding title}",
       type: "pattern",
       domain: "{relevant domain}",
@@ -182,7 +184,7 @@ After review, delete the branch and recreate fresh:
 
 ```
 YOUR_AGENT_branching op:vault_delete_branch
-  params: { name: "scout-findings" }
+  params: { branchName: "scout-findings" }
 YOUR_AGENT_branching op:vault_branch
   params: { name: "scout-findings" }
 ```

--- a/packages/forge/src/skills/soleri-retrospective/SKILL.md
+++ b/packages/forge/src/skills/soleri-retrospective/SKILL.md
@@ -14,7 +14,6 @@ Generate a data-driven retrospective from session data, vault captures, plan out
 
 ```
 YOUR_AGENT_core op:brain_stats
-YOUR_AGENT_core op:brain_stats params: { since: "<start of period>" }
 YOUR_AGENT_core op:brain_strengths
 YOUR_AGENT_core op:vault_recent
 YOUR_AGENT_core op:memory_topics
@@ -68,7 +67,7 @@ YOUR_AGENT_core op:capture_knowledge
     title: "Retrospective — [period]",
     description: "<key findings and action items>",
     type: "workflow",
-    category: "meta",
+    domain: "meta",
     tags: ["retrospective"]
   }
 ```

--- a/packages/forge/src/skills/soleri-second-opinion/SKILL.md
+++ b/packages/forge/src/skills/soleri-second-opinion/SKILL.md
@@ -38,7 +38,7 @@ YOUR_AGENT_core op:brain_recommend
 
 ```
 YOUR_AGENT_core op:memory_cross_project_search
-  params: { query: "<topic>", crossProject: true }
+  params: { query: "<topic>", projectPath: "." }
 ```
 
 **Web** — community consensus, benchmarks, comparison articles.
@@ -77,8 +77,8 @@ YOUR_AGENT_core op:capture_knowledge
   params: {
     title: "<decision title>",
     description: "<chosen option, rationale, rejected alternatives>",
-    type: "decision",
-    category: "<domain>",
+    type: "principle",
+    domain: "<domain>",
     tags: ["decision"]
   }
 ```

--- a/packages/forge/src/skills/soleri-subagent-driven-development/SKILL.md
+++ b/packages/forge/src/skills/soleri-subagent-driven-development/SKILL.md
@@ -178,7 +178,7 @@ Capture learnings to vault. Run `orchestrate_complete` for the parent plan.
 
 ```
 YOUR_AGENT_core op:capture_knowledge
-  params: { title: "<learned pattern>", description: "<merge strategy or decomposition insight>", type: "pattern", tags: ["subagent", "parallel-execution"] }
+  params: { title: "<learned pattern>", description: "<merge strategy or decomposition insight>", type: "pattern", domain: "orchestration", tags: ["subagent", "parallel-execution"] }
 ```
 
 ## Worktree & Branch Cleanup Guarantee

--- a/packages/forge/src/skills/soleri-systematic-debugging/SKILL.md
+++ b/packages/forge/src/skills/soleri-systematic-debugging/SKILL.md
@@ -67,7 +67,7 @@ YOUR_AGENT_core op:capture_knowledge
     title: "<bug>",
     description: "<root cause, solution, what made it hard to find>",
     type: "anti-pattern",
-    category: "<domain>",
+    domain: "<domain>",
     tags: ["<relevant>"]
   }
 YOUR_AGENT_core op:session_capture

--- a/packages/forge/src/skills/soleri-vault-capture/SKILL.md
+++ b/packages/forge/src/skills/soleri-vault-capture/SKILL.md
@@ -107,7 +107,7 @@ YOUR_AGENT_core op:capture_knowledge
       description: "<description>",
       type: "<type>",
       domain: "<domain>",
-      severity: "<critical|warning|suggestion>",
+      severity: "<critical|warning|info>",
       tags: ["<tag1>", "<tag2>"],
       why: "<reasoning>"
     }]
@@ -130,7 +130,7 @@ After capture, check EVERY response. Auto-detection frequently assigns "agent" t
 
 ```
 YOUR_AGENT_core op:vault_set_scope
-  params: { id: "<entry-id>", tier: "<correct-tier>" }
+  params: { id: "<entry-id>", tier: "project" }
 ```
 
 ### 9. Governance (if enabled)

--- a/packages/forge/src/skills/soleri-vault-curate/SKILL.md
+++ b/packages/forge/src/skills/soleri-vault-curate/SKILL.md
@@ -38,7 +38,7 @@ For true duplicates:
 
 ```
 YOUR_AGENT_core op:merge_patterns
-  params: { patternIds: ["<id1>", "<id2>"] }
+  params: { keepId: "<id-to-keep>", removeId: "<id-to-merge-away>" }
 ```
 
 Preserve the best content from each.
@@ -63,7 +63,7 @@ For targeted grooming of specific entries:
 
 ```
 YOUR_AGENT_core op:curator_groom
-  params: { entryIds: ["<id>"], tags: ["<tag>"] }
+  params: { entryId: "<id>" }
 ```
 
 ### Step 5: Full Consolidation

--- a/packages/forge/src/skills/soleri-vault-navigator/SKILL.md
+++ b/packages/forge/src/skills/soleri-vault-navigator/SKILL.md
@@ -37,7 +37,7 @@ YOUR_AGENT_core op:vault_age_report
 
 ```
 YOUR_AGENT_core op:memory_cross_project_search
-  params: { query: "<topic>", crossProject: true }
+  params: { query: "<topic>", projectPath: "." }
 YOUR_AGENT_core op:project_linked_projects
 ```
 

--- a/packages/forge/src/skills/soleri-writing-plans/SKILL.md
+++ b/packages/forge/src/skills/soleri-writing-plans/SKILL.md
@@ -43,8 +43,8 @@ Incorporate vault insights and web findings. Reference specific entries.
 YOUR_AGENT_core op:create_plan
   params: {
     objective: "<one-sentence goal>",
-    scope: { included: [...], excluded: [...] },
-    steps: [{ title: "Step 1", description: "details" }, ...],
+    scope: "<which parts of the codebase are affected>",
+    tasks: [{ title: "Step 1", description: "details" }],
     alternatives: [
       {
         approach: "<rejected approach>",
@@ -72,10 +72,10 @@ Iterate with alternatives:
 YOUR_AGENT_core op:plan_iterate
   params: {
     planId: "<id>",
-    feedback: "<improvement>",
+    objective: "<refined objective>",
     alternatives: [
-      { approach: "...", pros: [...], cons: [...], rejected_reason: "..." },
-      { approach: "...", pros: [...], cons: [...], rejected_reason: "..." }
+      { approach: "<option A>", pros: ["<pro>"], cons: ["<con>"], rejected_reason: "<why>" },
+      { approach: "<option B>", pros: ["<pro>"], cons: ["<con>"], rejected_reason: "<why>" }
     ]
   }
 ```


### PR DESCRIPTION
## Problem

`npm run validate-skills` reported 62 violations where SKILL.md op-call examples fail the real facade Zod schemas. These docs are what deployed agents follow — wrong examples cause runtime validation errors.

## What changed

### Skill doc fixes (26 SKILL.md files, packages/forge/src/skills)

| File | Fix |
|------|-----|
| soleri-agent-dev | `search_vault_intelligent`/`query_vault_knowledge` -> `search_intelligent`, `strengths` -> `brain_strengths`, `recommend` -> `brain_recommend` (with real params); `capture_knowledge` missing `domain` |
| soleri-agent-mode | `route_intent` `input`/`context` -> required `prompt` |
| soleri-brainstorming, soleri-discovery-phase, soleri-second-opinion | `type: "decision"` (invalid enum) -> `principle`; `category` -> `domain` |
| soleri-code-patrol, soleri-onboard-me | vault `search` missing required `query` |
| soleri-curator, soleri-vault-curate | `curator_groom` `entryIds`/`tags` -> required `entryId`; `merge_patterns` `patternIds` -> `keepId`/`removeId` |
| soleri-deep-review, soleri-deliver-and-ship, soleri-env-setup, soleri-finishing-a-development-branch, soleri-fix-and-learn, soleri-onboard-me, soleri-retrospective, soleri-subagent-driven-development, soleri-systematic-debugging | `capture_knowledge` missing required `domain` (and `category` -> `domain`) |
| soleri-health-check | `curator_resolve_contradiction` `contradictionId` -> required `id` (number) + `resolution` enum |
| soleri-intake | `ingest_book` (op does not exist) -> `ingest_text`; `ingest_batch` `sources` -> required `items` shape |
| soleri-loop | `loop_start` realistic `mode: "custom"`; `loop_status`/`loop_cancel` take no params — removed bogus params |
| soleri-parallel-execute | `update_task` `taskIndex` -> required `taskId`; `plan_reconcile` driftItems realistic enum values |
| soleri-research-scout | `vault_branch_add` `branch`/`entry` -> `branchName`/`entryId`/`action`/`entryData`; `vault_delete_branch` `name` -> `branchName` |
| soleri-retrospective | removed `brain_stats params: { since }` (op takes no params) |
| soleri-second-opinion, soleri-vault-navigator | `memory_cross_project_search` missing required `projectPath` |
| soleri-vault-capture | severity enum `suggestion` -> `info`; `vault_set_scope` realistic `tier: "project"` |
| soleri-knowledge-harvest | type placeholder listed invalid `decision` -> real enum members |
| soleri-writing-plans | `create_plan` `scope` object -> string, `steps` -> `tasks`; `plan_iterate` unknown key `feedback` removed (strict schema) |

### Validator fixes (packages/core/src/skills/validate-skill-docs.ts)

Four registry/parsing gaps caused false 'unknown op' and false enum errors:

1. **Schema-less ops were invisible** — ops without a params schema (`brain_stats`, `loop_status`, `loop_cancel`) were never registered and got reported as unknown. Now all ops register; schema-less ops are known but skip param validation.
2. **Op factories outside `runtime/facades` were not loaded** — `createCoreOps` (`activate`) and `createDreamOps` (`dream_run`) are now included (registry: 310 -> 404 ops).
3. **Zod v4 enum issue code** — placeholder filtering checked v3's `invalid_enum_value`; Zod v4 emits `invalid_value`, so pipe placeholders like `"approved|rejected"` were wrongly reported. Both codes are now recognized.
4. **Preprocessed schema paths** — `capture_knowledge` auto-wraps flat params into `entries[0]`, so issue paths did not resolve against the raw example when checking placeholders. Lookup now falls back through path suffixes.

No Zod schema was weakened — docs follow code. No genuinely wrong schemas were found.

### CI gate

- The script already exits non-zero on violations (verified); no `--strict` flag needed.
- Added `npm run validate-skills` to the **Code Quality** job in `.github/workflows/ci.yml` (runs from source via tsx, no build needed).

### Tests

`validate-skill-docs.test.ts` rewritten: previous tests asserted that drift exists (e.g. 'detects the create_plan scope mismatch' against live docs). Now fixture-based (temp skill dirs) covering unknown ops, missing params, enum errors, placeholder skipping, schema-less ops, and the new factories — plus a zero-violations gate on the shipped docs.

## Verification

- `npm run validate-skills` — 0 violations, exit 0 (126 examples, 404-op registry)
- `@soleri/core` vitest — 263 files, 5032 tests green (one unrelated flaky perf threshold in `vault-scaling.test.ts` passes on rerun)
- `npm run lint`, `typecheck`, `format:check`, `lint:md`, `lint:spell` — clean
- `e2e/skill-trigger-coverage.test.ts` — 9 passed