### PR TITLE
fix(forge/tests): give scaffold-heavy tests CI timeout headroom

### DIFF
--- a/packages/forge/src/__tests__/scaffolder.test.ts
+++ b/packages/forge/src/__tests__/scaffolder.test.ts
@@ -46,13 +46,17 @@ describe('Scaffolder', () => {
   let telegramDir: string;
   let telegramResult: ReturnType<typeof scaffold>;
 
-  beforeAll(() => {
-    baseDir = makeTempDir('base');
-    baseResult = scaffold({ ...baseConfig, outputDir: baseDir });
+  beforeAll(
+    () => {
+      baseDir = makeTempDir('base');
+      baseResult = scaffold({ ...baseConfig, outputDir: baseDir });
 
-    telegramDir = makeTempDir('telegram');
-    telegramResult = scaffold({ ...baseConfig, telegram: true, outputDir: telegramDir });
-  }, 60_000);
+      telegramDir = makeTempDir('telegram');
+      telegramResult = scaffold({ ...baseConfig, telegram: true, outputDir: telegramDir });
+      // Shared CI runners (macOS especially) run scaffold 3-4x slower than local.
+    },
+    process.env.CI ? 180_000 : 60_000,
+  );
 
   afterAll(() => {
     rmSync(baseDir, { recursive: true, force: true });

--- a/packages/forge/vitest.config.ts
+++ b/packages/forge/vitest.config.ts
@@ -5,7 +5,10 @@ export default defineConfig({
     environment: 'node',
     pool: 'forks',
     poolOptions: { forks: { singleFork: true } },
-    testTimeout: 30_000,
+    // Scaffold tests spawn npm/tsc subprocesses; shared CI runners (macOS
+    // especially) can be 3-4x slower than local, so give them headroom there.
+    testTimeout: process.env.CI ? 120_000 : 30_000,
+    hookTimeout: process.env.CI ? 120_000 : 10_000,
     exclude: ['**/node_modules/**', '**/.claude/worktrees/**'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
Forge scaffold suites spawn npm/tsc subprocesses; shared macOS runners ran them 3-4x slower than local today, producing four spurious red jobs (see #831). This raises timeouts under `CI` only: config-level 120s test/hook defaults plus 180s for scaffolder.test.ts's shared double-scaffold beforeAll. Local stays at 30s/60s so genuine hangs still surface fast during development.

Refs #831